### PR TITLE
fix: run migrations for sqlite providers

### DIFF
--- a/ActionScaffolder.cs
+++ b/ActionScaffolder.cs
@@ -1,0 +1,367 @@
+using System;
+using System.IO;
+using System.Linq;
+using DotNetArch.Scaffolding;
+using DotNetArch.Scaffolding.Steps;
+
+static class ActionScaffolder
+{
+    public static void Generate(SolutionConfig config, string entity, string action, bool isCommand)
+    {
+        if (string.IsNullOrWhiteSpace(config.SolutionName) || string.IsNullOrWhiteSpace(entity) || string.IsNullOrWhiteSpace(action))
+        {
+            Console.WriteLine("Solution, entity and action names are required.");
+            return;
+        }
+
+        var provider = config.DatabaseProvider;
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            provider = DatabaseProviderSelector.Choose();
+            config.DatabaseProvider = provider;
+            ConfigManager.Save(config.SolutionPath, config);
+        }
+
+        if (!provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!Program.EnsureEfTool(config.SolutionPath))
+            {
+                Console.WriteLine("❌ dotnet-ef installation failed; action generation canceled.");
+                return;
+            }
+        }
+        var steps = new IScaffoldStep[]
+        {
+            new ProjectUpdateStep(),
+            new EntityStep(),
+            new DbContextStep(),
+            new UnitOfWorkStep()
+        };
+        foreach (var step in steps)
+            step.Execute(config, entity);
+
+        AddRepositoryMethod(config, entity, action, isCommand);
+        AddApplicationFiles(config, entity, action, isCommand);
+        AddControllerMethod(config, entity, action, isCommand);
+
+        if (!provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
+        {
+            var prev = Directory.GetCurrentDirectory();
+            try
+            {
+                Directory.SetCurrentDirectory(config.SolutionPath);
+                if (Program.RunCommand("dotnet build", config.SolutionPath))
+                {
+                    var infraProj = $"{config.SolutionName}.Infrastructure/{config.SolutionName}.Infrastructure.csproj";
+                    var startProj = $"{config.StartupProject}/{config.StartupProject}.csproj";
+                    var migName = $"Auto_{entity}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+                    if (Program.RunCommand($"dotnet ef migrations add {migName} --project {infraProj} --startup-project {startProj} --output-dir Migrations", config.SolutionPath))
+                    {
+                        Program.RunCommand($"dotnet ef database update --project {infraProj} --startup-project {startProj}", config.SolutionPath);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("❌ Build failed; skipping migrations.");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(prev);
+            }
+        }
+
+        if (!config.Entities.TryGetValue(entity, out var state))
+            state = new EntityStatus();
+        state.HasAction = true;
+        config.Entities[entity] = state;
+        ConfigManager.Save(config.SolutionPath, config);
+
+        Console.WriteLine($"Action {action} for {entity} generated.");
+    }
+
+    static void AddRepositoryMethod(SolutionConfig config, string entity, string action, bool isCommand)
+    {
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+
+        var iface = Path.Combine(config.SolutionPath, $"{solution}.Core", "Features", plural, $"I{entity}Repository.cs");
+        Directory.CreateDirectory(Path.GetDirectoryName(iface)!);
+        if (!File.Exists(iface))
+        {
+            var iContent = """
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Core.Features.{{entities}};
+
+public interface I{{entity}}Repository
+{
+    {{methodSig}}
+}
+""";
+            var sig = isCommand
+                ? $"Task {Upper(action)}Async({entity} entity);"
+                : $"Task<{entity}?> {Upper(action)}Async(int id);";
+            File.WriteAllText(iface, iContent
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural)
+                .Replace("{{methodSig}}", sig));
+        }
+        else
+        {
+            var lines = File.ReadAllLines(iface).ToList();
+            if (!lines.Any(l => l.Contains($"{Upper(action)}Async")))
+            {
+                var idx = lines.FindLastIndex(l => l.Trim() == "}");
+                var sig = isCommand
+                    ? $"    Task {Upper(action)}Async({entity} entity);"
+                    : $"    Task<{entity}?> {Upper(action)}Async(int id);";
+                lines.Insert(idx, sig);
+                File.WriteAllLines(iface, lines);
+            }
+        }
+
+        var infraDir = Path.Combine(config.SolutionPath, $"{solution}.Infrastructure", "Features", plural);
+        var legacyInfraDir = Path.Combine(config.SolutionPath, $"{solution}.Infrastructure", plural);
+        var impl = Path.Combine(infraDir, $"{entity}Repository.cs");
+        var legacyRepo = Path.Combine(legacyInfraDir, $"{entity}Repository.cs");
+        if (File.Exists(legacyRepo) && !File.Exists(impl))
+        {
+            Directory.CreateDirectory(infraDir);
+            File.Move(legacyRepo, impl);
+            if (Directory.Exists(legacyInfraDir) && Directory.GetFileSystemEntries(legacyInfraDir).Length == 0)
+                Directory.Delete(legacyInfraDir, true);
+        }
+        else
+        {
+            Directory.CreateDirectory(infraDir);
+        }
+        if (!File.Exists(impl))
+        {
+            var mReturn = isCommand ? "Task" : $"Task<{entity}?>";
+            var param = isCommand ? $"{entity} entity" : "int id";
+            var body = isCommand
+                ? """
+        // TODO: implement action
+        await Task.CompletedTask;
+"""
+                : $"""
+        // TODO: implement action
+        return await _context.Set<{entity}>().FindAsync(id);
+""";
+            var rContent = """
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Infrastructure.Persistence;
+
+namespace {{solution}}.Infrastructure.Features.{{entities}};
+
+public class {{entity}}Repository : I{{entity}}Repository
+{
+    private readonly AppDbContext _context;
+    public {{entity}}Repository(AppDbContext context) => _context = context;
+
+    public async {{mReturn}} {{action}}Async({{param}})
+    {
+{{body}}    }
+}
+""";
+            File.WriteAllText(impl, rContent
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural)
+                .Replace("{{action}}", Upper(action))
+                .Replace("{{mReturn}}", mReturn)
+                .Replace("{{param}}", param)
+                .Replace("{{body}}", body));
+        }
+        else
+        {
+            var lines = File.ReadAllLines(impl).ToList();
+            if (!lines.Any(l => l.Contains($"{Upper(action)}Async(")))
+            {
+                var idx = lines.FindLastIndex(l => l.Trim() == "}");
+                var method = isCommand
+                    ? new[]
+                    {
+                        $"    public async Task {Upper(action)}Async({entity} entity)",
+                        "    {",
+                        "        // TODO: implement action",
+                        "        await Task.CompletedTask;",
+                        "    }",
+                    }
+                    : new[]
+                    {
+                        $"    public async Task<{entity}?> {Upper(action)}Async(int id)",
+                        "    {",
+                        "        // TODO: implement action",
+                        $"        return await _context.Set<{entity}>().FindAsync(id);",
+                        "    }",
+                    };
+                lines.InsertRange(idx, method);
+                File.WriteAllLines(impl, lines);
+            }
+        }
+    }
+
+    static void AddApplicationFiles(SolutionConfig config, string entity, string action, bool isCommand)
+    {
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+        var appBase = Path.Combine(config.SolutionPath, $"{solution}.Application", "Features", plural);
+        var dir = Path.Combine(appBase, isCommand ? "Commands" : "Queries", Upper(action));
+        Directory.CreateDirectory(dir);
+        string Fill(string t) => t.Replace("{{solution}}", solution)
+                                  .Replace("{{entity}}", entity)
+                                  .Replace("{{entities}}", plural)
+                                  .Replace("{{action}}", Upper(action));
+        if (isCommand)
+        {
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Command.cs"), Fill("""
+using MediatR;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.{{action}};
+
+public record {{action}}{{entity}}Command({{entity}} Entity) : IRequest;
+"""));
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Handler.cs"), Fill("""
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Interfaces;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.{{action}};
+
+public class {{action}}{{entity}}Handler : IRequestHandler<{{action}}{{entity}}Command>
+{
+    private readonly IUnitOfWork _uow;
+    public {{action}}{{entity}}Handler(IUnitOfWork uow) => _uow = uow;
+    public async Task Handle({{action}}{{entity}}Command request, CancellationToken ct)
+    {
+        await _uow.{{entity}}Repository.{{action}}Async(request.Entity);
+        await _uow.SaveChangesAsync();
+    }
+}
+"""));
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Validator.cs"), Fill("""
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.{{action}};
+
+public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entity}}Command>
+{
+    public {{action}}{{entity}}Validator()
+    {
+        RuleFor(x => x.Entity).NotNull();
+    }
+}
+"""));
+        }
+        else
+        {
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Query.cs"), Fill("""
+using MediatR;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.{{action}};
+
+public record {{action}}{{entity}}Query(int Id) : IRequest<{{entity}}?>;
+"""));
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Handler.cs"), Fill("""
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Interfaces;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.{{action}};
+
+public class {{action}}{{entity}}Handler : IRequestHandler<{{action}}{{entity}}Query, {{entity}}?>
+{
+    private readonly IUnitOfWork _uow;
+    public {{action}}{{entity}}Handler(IUnitOfWork uow) => _uow = uow;
+    public async Task<{{entity}}?> Handle({{action}}{{entity}}Query request, CancellationToken ct)
+        => await _uow.{{entity}}Repository.{{action}}Async(request.Id);
+}
+"""));
+            File.WriteAllText(Path.Combine(dir, $"{Upper(action)}{entity}Validator.cs"), Fill("""
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.{{action}};
+
+public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entity}}Query>
+{
+    public {{action}}{{entity}}Validator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+"""));
+        }
+    }
+
+    static void AddControllerMethod(SolutionConfig config, string entity, string action, bool isCommand)
+    {
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+        var apiDir = Path.Combine(config.SolutionPath, config.StartupProject, "Features", plural);
+        Directory.CreateDirectory(apiDir);
+        var file = Path.Combine(apiDir, $"{entity}Controller.cs");
+        var method = isCommand
+            ? new[]
+            {
+                $"    [HttpPost(\"{Upper(action)}\")]",
+                $"    public async Task<IActionResult> {Upper(action)}([FromBody] {entity} entity)",
+                "    {",
+                $"        await _mediator.Send(new {Upper(action)}{entity}Command(entity));",
+                "        return Ok();",
+                "    }",
+                ""
+            }
+            : new[]
+            {
+                $"    [HttpGet(\"{Upper(action)}/{{id}}\")]",
+                $"    public async Task<{entity}?> {Upper(action)}(int id)",
+                "        => await _mediator.Send(new " + Upper(action) + entity + "Query(id));",
+                ""
+            };
+        if (!File.Exists(file))
+        {
+            var content = string.Join(Environment.NewLine, new[]
+            {
+                "using MediatR;",
+                "using Microsoft.AspNetCore.Mvc;",
+                $"using {solution}.Core.Features.{plural};",
+                $"using {solution}.Application.Features.{plural}.{(isCommand ? "Commands" : "Queries")}.{Upper(action)};",
+                "",
+                $"namespace {config.StartupProject}.Features.{plural};",
+                "",
+                "[ApiController]",
+                "[Route(\"Api/[controller]\")]",
+                $"public class {entity}Controller : ControllerBase",
+                "{",
+                "    private readonly IMediator _mediator;",
+                $"    public {entity}Controller(IMediator mediator) => _mediator = mediator;",
+                ""
+            }.Concat(method).Concat(new[]{"}"}));
+            File.WriteAllText(file, content);
+        }
+        else
+        {
+            var lines = File.ReadAllLines(file).ToList();
+            var usingLine = $"using {solution}.Application.Features.{plural}.{(isCommand ? "Commands" : "Queries")}.{Upper(action)};";
+            var lastUsing = lines.FindLastIndex(l => l.StartsWith("using "));
+            if (!lines.Contains(usingLine))
+                lines.Insert(lastUsing + 1, usingLine);
+            var end = lines.FindLastIndex(l => l.Trim() == "}");
+            lines.InsertRange(end, method);
+            File.WriteAllLines(file, lines);
+        }
+    }
+
+    static string Upper(string text) => string.IsNullOrEmpty(text) ? text : char.ToUpper(text[0]) + text.Substring(1);
+}

--- a/ConfigManager.cs
+++ b/ConfigManager.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+
+public static class ConfigManager
+{
+    private const string FileName = "dotnet-arch.yml";
+
+    public static SolutionConfig? Load(string basePath)
+    {
+        var path = Path.Combine(basePath, FileName);
+        if (!File.Exists(path))
+            return null;
+        var lines = File.ReadAllLines(path);
+        var config = new SolutionConfig();
+        foreach (var line in lines)
+        {
+            var parts = line.Split(':', 2);
+            if (parts.Length != 2) continue;
+            var key = parts[0].Trim();
+            var value = parts[1].Trim();
+            if (key.Equals("solution", StringComparison.OrdinalIgnoreCase))
+                config.SolutionName = value;
+            else if (key.Equals("path", StringComparison.OrdinalIgnoreCase))
+                config.SolutionPath = value;
+            else if (key.Equals("startup", StringComparison.OrdinalIgnoreCase))
+                config.StartupProject = value;
+            else if (key.Equals("database", StringComparison.OrdinalIgnoreCase))
+                config.DatabaseProvider = value;
+            else if (key.Equals("style", StringComparison.OrdinalIgnoreCase))
+                config.ApiStyle = value;
+            else if (key.StartsWith("entity.", StringComparison.OrdinalIgnoreCase))
+            {
+                var name = key.Substring("entity.".Length);
+                var state = new EntityStatus
+                {
+                    HasCrud = value.Equals("crud", StringComparison.OrdinalIgnoreCase) || value.Equals("both", StringComparison.OrdinalIgnoreCase),
+                    HasAction = value.Equals("action", StringComparison.OrdinalIgnoreCase) || value.Equals("both", StringComparison.OrdinalIgnoreCase)
+                };
+                config.Entities[name] = state;
+            }
+        }
+        if (string.IsNullOrWhiteSpace(config.SolutionPath))
+            config.SolutionPath = basePath;
+        if (string.IsNullOrWhiteSpace(config.StartupProject))
+            config.StartupProject = $"{config.SolutionName}.API";
+        return config;
+    }
+
+    public static void Save(string basePath, SolutionConfig config)
+    {
+        var path = Path.Combine(basePath, FileName);
+        var nl = Environment.NewLine;
+        var content =
+            $"solution: {config.SolutionName}{nl}" +
+            $"path: {config.SolutionPath}{nl}" +
+            $"startup: {config.StartupProject}{nl}" +
+            $"style: {config.ApiStyle}{nl}";
+        if (!string.IsNullOrWhiteSpace(config.DatabaseProvider))
+            content += $"database: {config.DatabaseProvider}{nl}";
+        foreach (var kv in config.Entities)
+        {
+            var status = kv.Value.HasCrud && kv.Value.HasAction ? "both" : kv.Value.HasCrud ? "crud" : "action";
+            content += $"entity.{kv.Key}: {status}{nl}";
+        }
+        File.WriteAllText(path, content);
+    }
+}

--- a/CrudScaffolder.cs
+++ b/CrudScaffolder.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using DotNetArch.Scaffolding;
+using DotNetArch.Scaffolding.Steps;
+
+static class CrudScaffolder
+{
+    public static void Generate(SolutionConfig config, string entityName)
+    {
+        if (string.IsNullOrWhiteSpace(config.SolutionName) || string.IsNullOrWhiteSpace(entityName))
+        {
+            Console.WriteLine("Solution and entity names are required.");
+            return;
+        }
+
+        if (config.Entities.TryGetValue(entityName, out var existing) && existing.HasCrud)
+        {
+            Console.WriteLine($"CRUD for {entityName} already exists.");
+            return;
+        }
+
+        var provider = config.DatabaseProvider;
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            provider = DatabaseProviderSelector.Choose();
+            config.DatabaseProvider = provider;
+            ConfigManager.Save(config.SolutionPath, config);
+        }
+
+        if (!provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!Program.EnsureEfTool(config.SolutionPath))
+            {
+                Console.WriteLine("❌ dotnet-ef installation failed; CRUD generation canceled.");
+                return;
+            }
+        }
+        var controllerStep = config.ApiStyle.Equals("fast", StringComparison.OrdinalIgnoreCase)
+            ? (IScaffoldStep)new MinimalApiStep()
+            : new ControllerStep();
+
+        var steps = new IScaffoldStep[]
+        {
+            new ProjectUpdateStep(),
+            new EntityStep(),
+            new DbContextStep(),
+            new RepositoryStep(),
+            new UnitOfWorkStep(),
+            new ApplicationStep(),
+            controllerStep
+        };
+
+        foreach (var step in steps)
+            step.Execute(config, entityName);
+
+        if (!provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
+        {
+            var prev = Directory.GetCurrentDirectory();
+            try
+            {
+                Directory.SetCurrentDirectory(config.SolutionPath);
+                if (Program.RunCommand("dotnet build", config.SolutionPath))
+                {
+                    var infraProj = $"{config.SolutionName}.Infrastructure/{config.SolutionName}.Infrastructure.csproj";
+                    var startProj = $"{config.StartupProject}/{config.StartupProject}.csproj";
+                    var migName = $"Auto_{entityName}_{DateTime.UtcNow:yyyyMMddHHmmss}";
+                    if (Program.RunCommand($"dotnet ef migrations add {migName} --project {infraProj} --startup-project {startProj} --output-dir Migrations", config.SolutionPath))
+                    {
+                        Program.RunCommand($"dotnet ef database update --project {infraProj} --startup-project {startProj}", config.SolutionPath);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("❌ Build failed; skipping migrations.");
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(prev);
+            }
+        }
+
+        if (!config.Entities.TryGetValue(entityName, out var state))
+            state = new EntityStatus();
+        state.HasCrud = true;
+        config.Entities[entityName] = state;
+        ConfigManager.Save(config.SolutionPath, config);
+
+        Console.WriteLine($"CRUD for {entityName} generated using {provider} provider.");
+    }
+}

--- a/Main.cs
+++ b/Main.cs
@@ -2,69 +2,232 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using DotNetArch.Scaffolding;
+using DotNetArch.Scaffolding.Steps;
+
 class Program
 {
     static void Main(string[] args)
     {
-        Console.WriteLine("==========================================");
-        Console.WriteLine("🚀 Welcome to ScaffoldCleanArch Tool! 🚀");
-        Console.WriteLine("==========================================");
-        Console.WriteLine("A powerful solution scaffolding tool for Clean Architecture!");
-        Console.WriteLine("🔹 Generates a solution structure with core layers");
-        Console.WriteLine("🔹 Adds references between projects automatically");
-        Console.WriteLine("🔹 Ready to start coding your dream project!");
-        Console.WriteLine("==========================================\n");
-
-        Console.Write("Enter the name of your solution: ");
-        var solutionName = Console.ReadLine();
-
-        if (string.IsNullOrWhiteSpace(solutionName))
+        if (!EnsureDotnetSdk())
+            return;
+        if (args.Length >= 2 && args[0].ToLower() == "new" && args[1].ToLower() == "crud")
         {
-            Console.WriteLine("Solution name cannot be empty!");
+            string? entity = null;
+            string? outputPath = null;
+
+            for (int i = 2; i < args.Length; i++)
+            {
+                if (args[i].StartsWith("--entity="))
+                    entity = args[i].Substring("--entity=".Length);
+                else if (args[i].StartsWith("--output="))
+                    outputPath = args[i].Substring("--output=".Length);
+            }
+
+            if (string.IsNullOrWhiteSpace(entity))
+                entity = Ask("Enter entity name");
+            if (string.IsNullOrWhiteSpace(entity))
+            {
+                Error("Entity name is required.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(outputPath))
+                outputPath = Ask("Output path", Directory.GetCurrentDirectory());
+
+            var basePath = outputPath!;
+            var config = ConfigManager.Load(basePath);
+            if (config == null)
+            {
+                Error("Solution configuration not found. Run 'new solution' first.");
+                return;
+            }
+
+            CrudScaffolder.Generate(config, entity);
             return;
         }
 
-        // Create the solution folder
-        if (!Directory.Exists(solutionName))
+        if (args.Length >= 2 && args[0].ToLower() == "new" && args[1].ToLower() == "action")
         {
-            Directory.CreateDirectory(solutionName);
+            string? entity = null;
+            string? action = null;
+            string? outputPath = null;
+            bool? isCommand = null;
+
+            for (int i = 2; i < args.Length; i++)
+            {
+                if (args[i].StartsWith("--entity="))
+                    entity = args[i].Substring("--entity=".Length);
+                else if (args[i].StartsWith("--action="))
+                    action = args[i].Substring("--action=".Length);
+                else if (args[i].StartsWith("--is-command="))
+                    isCommand = bool.Parse(args[i].Substring("--is-command=".Length));
+                else if (args[i].StartsWith("--output="))
+                    outputPath = args[i].Substring("--output=".Length);
+            }
+
+            if (string.IsNullOrWhiteSpace(entity))
+                entity = Ask("Enter entity name");
+            if (string.IsNullOrWhiteSpace(action))
+                action = Ask("Enter action name");
+            if (string.IsNullOrWhiteSpace(entity) || string.IsNullOrWhiteSpace(action))
+            {
+                Error("Entity and action are required.");
+                return;
+            }
+
+            if (isCommand == null)
+                isCommand = Ask("Is command? (true/false)", "true").ToLower() != "false";
+            if (string.IsNullOrWhiteSpace(outputPath))
+                outputPath = Ask("Output path", Directory.GetCurrentDirectory());
+
+            var basePath = outputPath!;
+            var config = ConfigManager.Load(basePath);
+            if (config == null)
+            {
+                Error("Solution configuration not found. Run 'new solution' first.");
+                return;
+            }
+
+            ActionScaffolder.Generate(config, entity, action, isCommand.Value);
+            return;
         }
 
-        // Change working directory to the solution folder
-        Directory.SetCurrentDirectory(solutionName);
+        if (args.Length >= 2 && args[0].ToLower() == "new" && args[1].ToLower() == "solution")
+        {
+            string? solutionName = null;
+            string? outputPath = null;
+            string? startup = null;
+            string? style = null;
+            for (int i = 2; i < args.Length; i++)
+            {
+                if (!args[i].StartsWith("--"))
+                    solutionName = args[i];
+                else if (args[i].StartsWith("--output="))
+                    outputPath = args[i].Substring("--output=".Length);
+                else if (args[i].StartsWith("--startup="))
+                    startup = args[i].Substring("--startup=".Length);
+                else if (args[i].StartsWith("--style="))
+                    style = args[i].Substring("--style=".Length);
+            }
 
-        // Run `dotnet new` commands
+            if (string.IsNullOrWhiteSpace(solutionName))
+                solutionName = Ask("Enter solution name");
+            if (string.IsNullOrWhiteSpace(solutionName))
+            {
+                Error("Solution name is required.");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(outputPath))
+                outputPath = Ask("Output path", Directory.GetCurrentDirectory());
+            if (string.IsNullOrWhiteSpace(startup))
+                startup = Ask("Startup project", $"{solutionName}.API");
+            if (string.IsNullOrWhiteSpace(style))
+                style = AskOption("Select API style", new[] { "controller", "fast" }).ToLower();
+            if (string.IsNullOrWhiteSpace(style))
+                style = "controller";
+
+            GenerateSolution(solutionName, outputPath!, startup!, style!);
+            return;
+        }
+
+        GenerateSolutionInteractive();
+    }
+
+    static string Ask(string message, string? defaultValue = null)
+    {
+        Console.Write($"{message}{(defaultValue != null ? $" [{defaultValue}]" : "")}: ");
+        var input = Console.ReadLine();
+        return string.IsNullOrWhiteSpace(input) ? (defaultValue ?? string.Empty) : input;
+    }
+
+    static string AskOption(string message, string[] options, int defaultIndex = 0)
+    {
+        Console.WriteLine(message);
+        for (int i = 0; i < options.Length; i++)
+            Console.WriteLine($"{i + 1} - {options[i]}");
+        Console.Write($"Your choice [{defaultIndex + 1}]: ");
+        var input = Console.ReadLine();
+        return int.TryParse(input, out var idx) && idx >= 1 && idx <= options.Length
+            ? options[idx - 1]
+            : options[defaultIndex];
+    }
+
+    static void Info(string msg)
+    {
+        Console.WriteLine($"ℹ️ {msg}");
+        Console.WriteLine();
+    }
+
+    static void Success(string msg)
+    {
+        Console.WriteLine($"✅ {msg}");
+        Console.WriteLine();
+    }
+
+    static void Error(string msg)
+    {
+        Console.WriteLine($"❌ {msg}");
+        Console.WriteLine();
+    }
+
+    static void GenerateSolutionInteractive()
+    {
+        Info("Welcome to ScaffoldCleanArch Tool!");
+        var solutionName = Ask("Enter the name of your solution");
+        if (string.IsNullOrWhiteSpace(solutionName))
+        {
+            Error("Solution name cannot be empty!");
+            return;
+        }
+
+        var outputPath = Ask("Enter output path", Directory.GetCurrentDirectory());
+        var startup = Ask("Startup project", $"{solutionName}.API");
+        var style = AskOption("Select API style", new[] { "controller", "fast" }).ToLower();
+        if (string.IsNullOrWhiteSpace(style)) style = "controller";
+
+        GenerateSolution(solutionName, outputPath, startup, style);
+    }
+
+    static void GenerateSolution(string solutionName, string outputPath, string startupProject, string apiStyle)
+    {
+        var solutionDir = Path.Combine(outputPath, solutionName);
+        if (!Directory.Exists(solutionDir))
+            Directory.CreateDirectory(solutionDir);
+
+        Directory.SetCurrentDirectory(solutionDir);
+
         RunCommand($"dotnet new sln -n {solutionName}");
         RunCommand($"dotnet new classlib -n {solutionName}.Core");
         RunCommand($"dotnet new classlib -n {solutionName}.Application");
         RunCommand($"dotnet new classlib -n {solutionName}.Infrastructure");
         RunCommand($"dotnet new webapi -n {solutionName}.API");
 
-        // Remove default classes
         DeleteDefaultClass($"{solutionName}.Core");
         DeleteDefaultClass($"{solutionName}.Application");
         DeleteDefaultClass($"{solutionName}.Infrastructure");
 
-        // Add projects to the solution
         RunCommand($"dotnet sln add {solutionName}.Core/{solutionName}.Core.csproj");
         RunCommand($"dotnet sln add {solutionName}.Application/{solutionName}.Application.csproj");
         RunCommand($"dotnet sln add {solutionName}.Infrastructure/{solutionName}.Infrastructure.csproj");
         RunCommand($"dotnet sln add {solutionName}.API/{solutionName}.API.csproj");
 
-        // Add references between projects
         RunCommand($"dotnet add {solutionName}.Application/{solutionName}.Application.csproj reference {solutionName}.Core/{solutionName}.Core.csproj");
         RunCommand($"dotnet add {solutionName}.Infrastructure/{solutionName}.Infrastructure.csproj reference {solutionName}.Application/{solutionName}.Application.csproj");
         RunCommand($"dotnet add {solutionName}.API/{solutionName}.API.csproj reference {solutionName}.Application/{solutionName}.Application.csproj");
         RunCommand($"dotnet add {solutionName}.API/{solutionName}.API.csproj reference {solutionName}.Infrastructure/{solutionName}.Infrastructure.csproj");
 
-        Console.WriteLine("\n✅ Solution created successfully!");
-        Console.WriteLine("==========================================");
-        Console.WriteLine($"🌟 Navigate to the '{solutionName}' directory to explore your project.");
-        Console.WriteLine($"💻 Run 'dotnet build' to build the solution.");
-        Console.WriteLine($"🎉 Start coding your Clean Architecture project now!");
-        Console.WriteLine("==========================================");
+        var provider = DatabaseProviderSelector.Choose();
+        var config = new SolutionConfig { SolutionName = solutionName, SolutionPath = solutionDir, StartupProject = startupProject, DatabaseProvider = provider, ApiStyle = apiStyle };
+        ConfigManager.Save(solutionDir, config);
+        new ProjectUpdateStep().Execute(config, string.Empty);
+
+        Console.WriteLine();
+        Success("Solution created successfully!");
+        Info($"Navigate to the '{solutionName}' directory and run 'dotnet build'.");
     }
-    static void RunCommand(string command)
+    public static bool RunCommand(string command, string? workingDir = null, bool print = true)
     {
         string shell, shellArgs;
 
@@ -89,20 +252,62 @@ class Program
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
+                WorkingDirectory = workingDir ?? Directory.GetCurrentDirectory()
             }
         };
 
         process.Start();
         process.WaitForExit();
 
-        if (process.ExitCode != 0)
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        bool success = process.ExitCode == 0;
+
+        if (print)
         {
-            Console.WriteLine($"❌ Error: {process.StandardError.ReadToEnd()}");
+            if (!success)
+            {
+                var msg = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+                Error(string.IsNullOrWhiteSpace(msg) ? "Command failed" : msg.Trim());
+            }
+            else
+            {
+                Success(command);
+            }
         }
+
+        return success;
+    }
+
+    public static bool EnsureEfTool(string? workingDir = null)
+    {
+        if (RunCommand("dotnet ef --version", workingDir, print: false))
+            return true;
+
+        Console.WriteLine("ℹ️ dotnet-ef not found. Attempting installation...");
+        var cmd = GetEfToolInstallMessage();
+        if (RunCommand(cmd, workingDir))
+            return RunCommand("dotnet ef --version", workingDir, print: false);
+
+        Console.WriteLine($"❌ Failed to install dotnet-ef. Install manually with: {cmd}");
+        return false;
+    }
+
+    public static bool EnsureDotnetSdk()
+    {
+        if (RunCommand("dotnet --version", print: false))
+            return true;
+
+        Console.WriteLine("❌ .NET SDK not found. Install from https://dotnet.microsoft.com/download");
+        return false;
+    }
+
+    public static string GetEfToolInstallMessage()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "dotnet tool install --global dotnet-ef && setx PATH \"%PATH%;%USERPROFILE%\\.dotnet\\tools\"";
         else
-        {
-            Console.WriteLine($"✅ {process.StandardOutput.ReadToEnd()}");
-        }
+            return "dotnet tool install --global dotnet-ef && export PATH=\"$PATH:$HOME/.dotnet/tools\"";
     }
 
     static void DeleteDefaultClass(string projectName)

--- a/README.MD
+++ b/README.MD
@@ -45,22 +45,66 @@ dotnet tool update --global DotNetArch
 ```  
 
 **Step 3: Generate a Clean Architecture Solution**  
-Once installed, you can use the tool to create a solution structure:  
+Once installed, you can use the tool to create a solution structure:
 
 ```bash
-dotnet arch
-```  
+dotnet-arch new solution <SolutionName> [--output=Path] [--startup=ProjectName] [--style=controller|fast]
+```
 
-This command generates the following layers:  
+`--output` is optional and lets you specify where the solution is created (useful for tests). If omitted, the current directory is used. `--startup` lets you choose which project should act as the startup project (default is `<SolutionName>.API`). `--style` selects between classic **Controller** APIs or lightweight **Fast** minimal APIs (default `controller`). Missing parameters are prompted interactively with defaults shown in brackets; when selecting API style, simply enter **1** for Controller or **2** for Fast. During creation you'll be prompted for a database provider (SQL Server or SQLite; hitting enter selects SQLite). After scaffolding, a `dotnet-arch.yml` file records the solution name, path, startup project, API style, chosen provider, and the scaffolding state of each entity so later commands can skip work already done. Swagger and service registrations are configured at this stage so the API runs immediately.
 
-- **Core**  
-- **Application**  
-- **Infrastructure**  
-- **API**  
+This command generates the following layers:
+
+- **Core**
+- **Application**
+- **Infrastructure**
+- **API**
+
+#### Generate CRUD for an Entity
+
+After creating a solution you can scaffold a full CRUD vertical slice for an entity:
+
+```bash
+dotnet-arch new crud --entity=EntityName [--output=Path]
+```
+
+`--output` points to the solution directory; if omitted, the current directory is used. If required arguments are missing the CLI prompts for them. The command reads `dotnet-arch.yml` to locate the solution name and scaffolds the entity slice. Depending on the selected style it creates either API controllers or minimal FastAPI endpoints along with domain models, repositories, unit of work, MediatR handlers and validators. The CLI installs `dotnet-ef` if needed and runs migrations for relational providers (SQL Server, SQLite, PostgreSQL) so schema changes are applied automatically. Each entity is placed under a `Features/<Entity>` folder in every layer and follows a CQRS-aware vertical slice:
+
+```
+Application/<Entity>/
+├── Commands/
+│   ├── Create/
+│   ├── Update/
+│   └── Delete/
+└── Queries/
+    ├── GetById/
+    ├── GetAll/
+    └── GetList/
+```
+
+Every operation folder under Commands or Queries contains the request, its handler, and a corresponding validator. The first time you scaffold an entity you choose either SQL Server or SQLite and the choice is saved to `dotnet-arch.yml` so later `new crud` runs reuse the same provider. Generated code supports pagination via `PagedResult<T>` and re-running the command updates existing files instead of duplicating them.
+
+All controller routes and endpoint paths are emitted in **PascalCase** (for example, `/Api/Product/All`).
+
+#### Add a Custom Action
+
+Extend an existing slice or create a minimal slice with a single action:
+
+```
+dotnet-arch new action --entity=EntityName --action=download --output=../MyApp
+```
+
+When running outside the solution directory, pass `--output` so the tool can locate `dotnet-arch.yml`. By default the action is treated as a command. To scaffold a query instead, append `--is-command=false`:
+
+```
+dotnet-arch new action --entity=EntityName --action=getfile --is-command=false --output=../MyApp
+```
+
+The tool generates the command or query, handler, validator, repository method, and controller endpoint for the specified action. If the entity slice is missing, a minimal repository and controller are also created with only this action stub. Migrations are applied automatically after scaffolding so the database stays in sync.
 
 ---
 
-#### **How to Clone and Run the Project**  
+#### **How to Clone and Run the Project**
 
 **Step 1: Clone the Repository**  
 
@@ -115,12 +159,25 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 
 ---
 
-#### **Features**  
+#### **Features**
 
-- **Automated Project Setup**: Generate Clean Architecture solutions with a single command.  
-- **Cross-Platform**: Fully functional on Windows, macOS, and Linux.  
-- **Domain-Driven Design Support**: Includes pre-configured layers for DDD.  
-- **Ease of Use**: Intuitive and straightforward CLI commands.  
+- **Automated Project Setup**: Generate Clean Architecture solutions with a single command.
+- **Cross-Platform**: Fully functional on Windows, macOS, and Linux.
+- **Domain-Driven Design Support**: Includes pre-configured layers for DDD.
+- **Ease of Use**: Intuitive and straightforward CLI commands.
+- **`new crud` scaffolding**: Generates vertical-slice CQRS CRUD with MediatR, FluentValidation, EF Core repositories, and paginated results.
+- **Database Provider Selection**: Choose between SQL Server, SQLite, PostgreSQL or MongoDB (default SQLite); the selected provider is stored so future runs don't prompt again.
+- **Idempotent Generation**: Re-running commands updates existing files without creating duplicates.
+- **Repository & Unit of Work patterns**: Each entity gets its own repository and UoW registration for clean data access.
+- **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.
+- **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
+- **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
+- **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
+- **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.
+- **Custom output path**: Both `new solution` and `new crud` accept an `--output` option so code can be generated in test directories or alternative locations.
+- **Development Swagger setup**: API projects automatically reference `Microsoft.AspNetCore.OpenApi` and `Swashbuckle.AspNetCore`, register Swagger services, and enable Swagger UI in development while removing default template files and sample endpoints.
+- **Feature-based folder structure**: Each layer organizes code under `Features/<Entity>` so all slices stay grouped.
+  - **Automatic migrations**: `new crud` and `new action` verify `dotnet-ef` and attempt installation if needed. For relational providers (SQL Server, SQLite, PostgreSQL) migrations and database updates run automatically; for MongoDB the process skips migrations. Generated `Program.cs` calls `Database.Migrate()` on startup to apply any pending migrations so new tables are created automatically.
 
 ---
 

--- a/Scaffolding/DatabaseProviderSelector.cs
+++ b/Scaffolding/DatabaseProviderSelector.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace DotNetArch.Scaffolding;
+
+public static class DatabaseProviderSelector
+{
+    public static string Choose()
+    {
+        Console.WriteLine("Select database provider (default SQLite):");
+        Console.WriteLine("1 - SQL Server");
+        Console.WriteLine("2 - SQLite");
+        Console.WriteLine("3 - PostgreSQL");
+        Console.WriteLine("4 - MongoDB");
+        Console.Write("Your choice: ");
+        var choice = Console.ReadLine();
+        return choice switch
+        {
+            "1" => "SqlServer",
+            "3" => "Postgres",
+            "4" => "Mongo",
+            _   => "SQLite"
+        };
+    }
+}

--- a/Scaffolding/IScaffoldStep.cs
+++ b/Scaffolding/IScaffoldStep.cs
@@ -1,0 +1,6 @@
+namespace DotNetArch.Scaffolding;
+
+public interface IScaffoldStep
+{
+    void Execute(SolutionConfig config, string entity);
+}

--- a/Scaffolding/Naming.cs
+++ b/Scaffolding/Naming.cs
@@ -1,0 +1,19 @@
+namespace DotNetArch.Scaffolding;
+
+public static class Naming
+{
+    public static string Pluralize(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return name;
+        var lower = name.ToLowerInvariant();
+        if (lower.EndsWith("y") && name.Length > 1 && !IsVowel(lower[lower.Length - 2]))
+            return name.Substring(0, name.Length - 1) + "ies";
+        if (lower.EndsWith("s") || lower.EndsWith("x") || lower.EndsWith("z") ||
+            lower.EndsWith("ch") || lower.EndsWith("sh"))
+            return name + "es";
+        return name + "s";
+    }
+
+    static bool IsVowel(char c) => "aeiou".IndexOf(c) >= 0;
+}
+

--- a/Scaffolding/Steps/ApplicationStep.cs
+++ b/Scaffolding/Steps/ApplicationStep.cs
@@ -1,0 +1,287 @@
+using System;
+using System.IO;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class ApplicationStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var plural = Naming.Pluralize(entity);
+        var appRoot = Path.Combine(basePath, $"{solution}.Application");
+        Directory.CreateDirectory(appRoot);
+        var marker = Path.Combine(appRoot, "AssemblyMarker.cs");
+        if (!File.Exists(marker))
+        {
+            var markerContent = $"namespace {solution}.Application;{Environment.NewLine}{Environment.NewLine}public class AssemblyMarker {{ }}{Environment.NewLine}";
+            File.WriteAllText(marker, markerContent);
+        }
+        var appBase = Path.Combine(appRoot, "Features", plural);
+        Directory.CreateDirectory(appBase);
+
+        var commandsDir = Path.Combine(appBase, "Commands");
+        var queriesDir = Path.Combine(appBase, "Queries");
+        Directory.CreateDirectory(commandsDir);
+        Directory.CreateDirectory(queriesDir);
+
+        string Fill(string template) => template
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural);
+
+        // Commands
+        var createDir = Path.Combine(commandsDir, "Create");
+        Directory.CreateDirectory(createDir);
+        File.WriteAllText(Path.Combine(createDir, $"Create{entity}Command.cs"), Fill(@"
+using MediatR;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Create;
+
+public record Create{{entity}}Command({{entity}} Entity) : IRequest<{{entity}}>;
+"));
+        File.WriteAllText(Path.Combine(createDir, $"Create{entity}Handler.cs"), Fill(@"
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Create;
+
+public class Create{{entity}}Handler : IRequestHandler<Create{{entity}}Command, {{entity}}>
+{
+    private readonly IUnitOfWork _uow;
+    public Create{{entity}}Handler(IUnitOfWork uow) => _uow = uow;
+    public async Task<{{entity}}> Handle(Create{{entity}}Command request, CancellationToken ct)
+    {
+        await _uow.{{entity}}Repository.AddAsync(request.Entity);
+        await _uow.SaveChangesAsync();
+        return request.Entity;
+    }
+}
+"));
+        File.WriteAllText(Path.Combine(createDir, $"Create{entity}Validator.cs"), Fill(@"
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Create;
+
+public class Create{{entity}}Validator : AbstractValidator<Create{{entity}}Command>
+{
+    public Create{{entity}}Validator()
+    {
+        RuleFor(x => x.Entity.Id).GreaterThanOrEqualTo(0);
+    }
+}
+"));
+
+        var updateDir = Path.Combine(commandsDir, "Update");
+        Directory.CreateDirectory(updateDir);
+        File.WriteAllText(Path.Combine(updateDir, $"Update{entity}Command.cs"), Fill(@"
+using MediatR;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Update;
+
+public record Update{{entity}}Command({{entity}} Entity) : IRequest;
+"));
+        File.WriteAllText(Path.Combine(updateDir, $"Update{entity}Handler.cs"), Fill(@"
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Update;
+
+public class Update{{entity}}Handler : IRequestHandler<Update{{entity}}Command>
+{
+    private readonly IUnitOfWork _uow;
+    public Update{{entity}}Handler(IUnitOfWork uow) => _uow = uow;
+    public async Task Handle(Update{{entity}}Command request, CancellationToken ct)
+    {
+        await _uow.{{entity}}Repository.UpdateAsync(request.Entity);
+        await _uow.SaveChangesAsync();
+    }
+}
+"));
+        File.WriteAllText(Path.Combine(updateDir, $"Update{entity}Validator.cs"), Fill(@"
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Update;
+
+public class Update{{entity}}Validator : AbstractValidator<Update{{entity}}Command>
+{
+    public Update{{entity}}Validator()
+    {
+        RuleFor(x => x.Entity.Id).GreaterThan(0);
+    }
+}
+"));
+
+        var deleteDir = Path.Combine(commandsDir, "Delete");
+        Directory.CreateDirectory(deleteDir);
+        File.WriteAllText(Path.Combine(deleteDir, $"Delete{entity}Command.cs"), Fill(@"
+using MediatR;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Delete;
+
+public record Delete{{entity}}Command(int Id) : IRequest;
+"));
+        File.WriteAllText(Path.Combine(deleteDir, $"Delete{entity}Handler.cs"), Fill(@"
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Delete;
+
+public class Delete{{entity}}Handler : IRequestHandler<Delete{{entity}}Command>
+{
+    private readonly IUnitOfWork _uow;
+    public Delete{{entity}}Handler(IUnitOfWork uow) => _uow = uow;
+    public async Task Handle(Delete{{entity}}Command request, CancellationToken ct)
+    {
+        var entity = await _uow.{{entity}}Repository.GetByIdAsync(request.Id);
+        if (entity != null)
+        {
+            await _uow.{{entity}}Repository.DeleteAsync(entity);
+            await _uow.SaveChangesAsync();
+        }
+    }
+}
+"));
+        File.WriteAllText(Path.Combine(deleteDir, $"Delete{entity}Validator.cs"), Fill(@"
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Commands.Delete;
+
+public class Delete{{entity}}Validator : AbstractValidator<Delete{{entity}}Command>
+{
+    public Delete{{entity}}Validator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+"));
+
+        // Queries
+        var getByIdDir = Path.Combine(queriesDir, "GetById");
+        Directory.CreateDirectory(getByIdDir);
+        File.WriteAllText(Path.Combine(getByIdDir, $"Get{entity}ByIdQuery.cs"), Fill(@"
+using MediatR;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetById;
+
+public record Get{{entity}}ByIdQuery(int Id) : IRequest<{{entity}}?>;
+"));
+        File.WriteAllText(Path.Combine(getByIdDir, $"Get{entity}ByIdHandler.cs"), Fill(@"
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetById;
+
+public class Get{{entity}}ByIdHandler : IRequestHandler<Get{{entity}}ByIdQuery, {{entity}}?>
+{
+    private readonly IUnitOfWork _uow;
+    public Get{{entity}}ByIdHandler(IUnitOfWork uow) => _uow = uow;
+    public async Task<{{entity}}?> Handle(Get{{entity}}ByIdQuery request, CancellationToken ct)
+        => await _uow.{{entity}}Repository.GetByIdAsync(request.Id);
+}
+"));
+        File.WriteAllText(Path.Combine(getByIdDir, $"Get{entity}ByIdValidator.cs"), Fill(@"
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetById;
+
+public class Get{{entity}}ByIdValidator : AbstractValidator<Get{{entity}}ByIdQuery>
+{
+    public Get{{entity}}ByIdValidator()
+    {
+        RuleFor(x => x.Id).GreaterThan(0);
+    }
+}
+"));
+
+        var getAllDir = Path.Combine(queriesDir, "GetAll");
+        Directory.CreateDirectory(getAllDir);
+        File.WriteAllText(Path.Combine(getAllDir, $"Get{entity}AllQuery.cs"), Fill(@"
+using MediatR;
+using System.Collections.Generic;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetAll;
+
+public record Get{{entity}}AllQuery() : IRequest<List<{{entity}}>>;
+"));
+        File.WriteAllText(Path.Combine(getAllDir, $"Get{entity}AllHandler.cs"), Fill(@"
+using MediatR;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetAll;
+
+public class Get{{entity}}AllHandler : IRequestHandler<Get{{entity}}AllQuery, List<{{entity}}>>
+{
+    private readonly IUnitOfWork _uow;
+    public Get{{entity}}AllHandler(IUnitOfWork uow) => _uow = uow;
+    public async Task<List<{{entity}}>> Handle(Get{{entity}}AllQuery request, CancellationToken ct)
+        => await _uow.{{entity}}Repository.GetAllAsync();
+}
+"));
+
+        var getListDir = Path.Combine(queriesDir, "GetList");
+        Directory.CreateDirectory(getListDir);
+        File.WriteAllText(Path.Combine(getListDir, $"Get{entity}ListQuery.cs"), Fill(@"
+using MediatR;
+using {{solution}}.Core.Common;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetList;
+
+public record Get{{entity}}ListQuery(int Page = 1, int PageSize = 10) : IRequest<PagedResult<{{entity}}>>;
+"));
+        File.WriteAllText(Path.Combine(getListDir, $"Get{entity}ListHandler.cs"), Fill(@"
+using MediatR;
+using System.Threading;
+using System.Threading.Tasks;
+using {{solution}}.Core.Common;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetList;
+
+public class Get{{entity}}ListHandler : IRequestHandler<Get{{entity}}ListQuery, PagedResult<{{entity}}>>
+{
+    private readonly IUnitOfWork _uow;
+    public Get{{entity}}ListHandler(IUnitOfWork uow) => _uow = uow;
+    public async Task<PagedResult<{{entity}}>> Handle(Get{{entity}}ListQuery request, CancellationToken ct)
+        => await _uow.{{entity}}Repository.ListAsync(request.Page, request.PageSize);
+}
+"));
+        File.WriteAllText(Path.Combine(getListDir, $"Get{entity}ListValidator.cs"), Fill(@"
+using FluentValidation;
+
+namespace {{solution}}.Application.Features.{{entities}}.Queries.GetList;
+
+public class Get{{entity}}ListValidator : AbstractValidator<Get{{entity}}ListQuery>
+{
+    public Get{{entity}}ListValidator()
+    {
+        RuleFor(x => x.Page).GreaterThan(0);
+        RuleFor(x => x.PageSize).GreaterThan(0);
+    }
+}
+"));
+    }
+}

--- a/Scaffolding/Steps/ControllerStep.cs
+++ b/Scaffolding/Steps/ControllerStep.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class ControllerStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var startupProject = config.StartupProject;
+        var plural = Naming.Pluralize(entity);
+        var apiDir = Path.Combine(basePath, startupProject, "Features", plural);
+        Directory.CreateDirectory(apiDir);
+        var controllerFile = Path.Combine(apiDir, $"{entity}Controller.cs");
+        var content = """
+using MediatR;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using {{solution}}.Application.Features.{{entities}}.Commands.Create;
+using {{solution}}.Application.Features.{{entities}}.Commands.Update;
+using {{solution}}.Application.Features.{{entities}}.Commands.Delete;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetById;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetAll;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetList;
+using {{solution}}.Core.Common;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{startupProject}}.Features.{{entities}};
+
+[ApiController]
+[Route("Api/[controller]")]
+public class {{entity}}Controller : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public {{entity}}Controller(IMediator mediator) => _mediator = mediator;
+
+    [HttpGet("{id}")]
+    public async Task<{{entity}}?> GetById(int id) => await _mediator.Send(new Get{{entity}}ByIdQuery(id));
+
+    [HttpGet("All")]
+    public async Task<List<{{entity}}>> GetAll() => await _mediator.Send(new Get{{entity}}AllQuery());
+
+    [HttpGet("List")]
+    public async Task<PagedResult<{{entity}}>> GetList([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+        => await _mediator.Send(new Get{{entity}}ListQuery(page, pageSize));
+
+    [HttpPost]
+    public async Task<{{entity}}> Create([FromBody] {{entity}} entity) =>
+        await _mediator.Send(new Create{{entity}}Command(entity));
+
+    [HttpPut("{id}")]
+    public async Task Update(int id, [FromBody] {{entity}} entity)
+    {
+        entity.Id = id;
+        await _mediator.Send(new Update{{entity}}Command(entity));
+    }
+
+    [HttpDelete("{id}")]
+    public async Task Delete(int id) => await _mediator.Send(new Delete{{entity}}Command(id));
+}
+""";
+        content = content
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural)
+            .Replace("{{startupProject}}", startupProject);
+        if (!File.Exists(controllerFile))
+        {
+            File.WriteAllText(controllerFile, content);
+        }
+        else
+        {
+            var text = File.ReadAllText(controllerFile);
+            if (!text.Contains("IMediator _mediator"))
+            {
+                var classIdx = text.IndexOf("{", text.IndexOf("class", StringComparison.Ordinal));
+                text = text.Insert(classIdx + 1, "\n    private readonly IMediator _mediator;\n");
+            }
+            if (!text.Contains($"public {entity}Controller(IMediator mediator)"))
+            {
+                var classIdx = text.IndexOf("{", text.IndexOf("class", StringComparison.Ordinal));
+                var ctor = $"\n    public {entity}Controller(IMediator mediator) => _mediator = mediator;\n";
+                text = text.Insert(classIdx + 1, ctor);
+            }
+            var methods = new Dictionary<string,string>
+            {
+                {"GetById", "    [HttpGet(\"{id}\")]\n    public async Task<"+entity+"?> GetById(int id) => await _mediator.Send(new Get"+entity+"ByIdQuery(id));\n"},
+                {"GetAll", "    [HttpGet(\"All\")]\n    public async Task<List<"+entity+">> GetAll() => await _mediator.Send(new Get"+entity+"AllQuery());\n"},
+                {"GetList", "    [HttpGet(\"List\")]\n    public async Task<PagedResult<"+entity+">> GetList([FromQuery] int page = 1, [FromQuery] int pageSize = 10)\n        => await _mediator.Send(new Get"+entity+"ListQuery(page, pageSize));\n"},
+                {"Create", "    [HttpPost]\n    public async Task<"+entity+"> Create([FromBody] "+entity+" entity) =>\n        await _mediator.Send(new Create"+entity+"Command(entity));\n"},
+                {"Update", "    [HttpPut(\"{id}\")]\n    public async Task Update(int id, [FromBody] "+entity+" entity)\n    {\n        entity.Id = id;\n        await _mediator.Send(new Update"+entity+"Command(entity));\n    }\n"},
+                {"Delete", "    [HttpDelete(\"{id}\")]\n    public async Task Delete(int id) => await _mediator.Send(new Delete"+entity+"Command(id));\n"}
+            };
+            foreach (var kv in methods)
+            {
+                if (!text.Contains(kv.Key))
+                {
+                    var idx = text.LastIndexOf("}");
+                    text = text.Insert(idx, kv.Value);
+                }
+            }
+            var requiredUsings = new[]
+            {
+                "using MediatR;",
+                "using System.Collections.Generic;",
+                "using System.Threading.Tasks;",
+                "using Microsoft.AspNetCore.Mvc;",
+                $"using {solution}.Application.Features.{plural}.Commands.Create;",
+                $"using {solution}.Application.Features.{plural}.Commands.Update;",
+                $"using {solution}.Application.Features.{plural}.Commands.Delete;",
+                $"using {solution}.Application.Features.{plural}.Queries.GetById;",
+                $"using {solution}.Application.Features.{plural}.Queries.GetAll;",
+                $"using {solution}.Application.Features.{plural}.Queries.GetList;",
+                $"using {solution}.Core.Common;",
+                $"using {solution}.Core.Features.{plural};"
+            };
+            foreach (var u in requiredUsings)
+                if (!text.Contains(u))
+                    text = u + Environment.NewLine + text;
+            File.WriteAllText(controllerFile, text);
+        }
+    }
+}
+

--- a/Scaffolding/Steps/DbContextStep.cs
+++ b/Scaffolding/Steps/DbContextStep.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Linq;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class DbContextStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var plural = Naming.Pluralize(entity);
+        var dir = Path.Combine(basePath, $"{solution}.Infrastructure", "Persistence");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "AppDbContext.cs");
+        if (!File.Exists(file))
+        {
+            var content = """
+using Microsoft.EntityFrameworkCore;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Infrastructure.Persistence;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<{{entity}}> {{entities}} { get; set; }
+}
+""";
+            File.WriteAllText(file, content
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural));
+        }
+        else
+        {
+            var lines = File.ReadAllLines(file).ToList();
+            var usingLine = $"using {solution}.Core.Features.{plural};";
+            if (!lines.Contains(usingLine))
+                lines.Insert(0, usingLine);
+
+            var propLine = $"    public DbSet<{entity}> {plural} {{ get; set; }}";
+            if (!lines.Any(l => l.Contains($"DbSet<{entity}>") ))
+            {
+                var insertIndex = lines.Count - 2;
+                lines.Insert(insertIndex, propLine);
+            }
+            File.WriteAllLines(file, lines);
+        }
+    }
+}
+

--- a/Scaffolding/Steps/EntityStep.cs
+++ b/Scaffolding/Steps/EntityStep.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class EntityStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var plural = Naming.Pluralize(entity);
+        var dir = Path.Combine(basePath, $"{solution}.Core", "Features", plural);
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, $"{entity}.cs");
+        if (File.Exists(file)) return;
+        var content = """
+namespace {{solution}}.Core.Features.{{entities}};
+
+public class {{entity}}
+{
+    public int Id { get; set; }
+}
+""";
+        File.WriteAllText(file, content
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural));
+    }
+}

--- a/Scaffolding/Steps/MinimalApiStep.cs
+++ b/Scaffolding/Steps/MinimalApiStep.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class MinimalApiStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var startupProject = config.StartupProject;
+        var plural = Naming.Pluralize(entity);
+        var apiDir = Path.Combine(basePath, startupProject, "Features", plural);
+        Directory.CreateDirectory(apiDir);
+        var file = Path.Combine(apiDir, $"{entity}Endpoints.cs");
+        if (File.Exists(file)) return;
+        var content = """
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using {{solution}}.Application.Features.{{entities}}.Commands.Create;
+using {{solution}}.Application.Features.{{entities}}.Commands.Update;
+using {{solution}}.Application.Features.{{entities}}.Commands.Delete;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetById;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetAll;
+using {{solution}}.Application.Features.{{entities}}.Queries.GetList;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Common;
+
+namespace {{startupProject}}.Features.{{entities}};
+
+public static class {{entity}}Endpoints
+{
+    public static void Map{{entity}}Endpoints(this IEndpointRouteBuilder routes)
+    {
+        routes.MapGet("/Api/{{entity}}/{id}", async (IMediator mediator, int id) =>
+            await mediator.Send(new Get{{entity}}ByIdQuery(id)) is {{entity}} result ? Results.Ok(result) : Results.NotFound());
+
+        routes.MapGet("/Api/{{entity}}/All", async (IMediator mediator) =>
+            Results.Ok(await mediator.Send(new Get{{entity}}AllQuery())));
+
+        routes.MapGet("/Api/{{entity}}/List", async (IMediator mediator, int page, int pageSize) =>
+            Results.Ok(await mediator.Send(new Get{{entity}}ListQuery(page, pageSize))));
+
+        routes.MapPost("/Api/{{entity}}", async (IMediator mediator, {{entity}} entity) =>
+        {
+            var created = await mediator.Send(new Create{{entity}}Command(entity));
+            return Results.Created($"/Api/{{entity}}/{created.Id}", created);
+        });
+
+        routes.MapPut("/Api/{{entity}}/{id}", async (IMediator mediator, int id, {{entity}} entity) =>
+        {
+            entity.Id = id;
+            await mediator.Send(new Update{{entity}}Command(entity));
+            return Results.NoContent();
+        });
+
+        routes.MapDelete("/Api/{{entity}}/{id}", async (IMediator mediator, int id) =>
+        {
+            await mediator.Send(new Delete{{entity}}Command(id));
+            return Results.NoContent();
+        });
+    }
+}
+""";
+        File.WriteAllText(file, content
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural)
+            .Replace("{{startupProject}}", startupProject));
+    }
+}

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class ProjectUpdateStep : IScaffoldStep
+{
+    private const string MediatRVersion = "12.1.1";
+    private const string FluentValidationVersion = "11.9.0";
+    // EF Core 9 is required to match the dotnet-ef tool installed by the scaffolded project
+    private const string EfCoreVersion = "9.0.0";
+    private const string SqlClientVersion = "5.2.1";
+    private const string OpenApiVersion = "9.0.0";
+    private const string SwaggerVersion = "6.5.0";
+
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var provider = config.DatabaseProvider;
+        var basePath = config.SolutionPath;
+        var startupProject = config.StartupProject;
+        var apiStyle = config.ApiStyle;
+        var infraPath = Path.Combine(basePath, $"{solution}.Infrastructure");
+        if (provider == "SQLite")
+        {
+            var dataDir = Path.Combine(infraPath, "Data");
+            Directory.CreateDirectory(dataDir);
+        }
+        Directory.CreateDirectory(Path.Combine(infraPath, "Migrations"));
+        UpdateApplicationProject(solution, basePath);
+        UpdateInfrastructureProject(solution, basePath, provider);
+        UpdateApiProject(solution, provider, basePath, startupProject);
+        RemoveTemplateFiles(basePath, startupProject);
+        UpdateProgram(solution, provider, entity, basePath, startupProject, apiStyle);
+    }
+
+    static void EnsurePackage(XDocument doc, string include, string version)
+    {
+        var refs = doc.Root!.Elements("ItemGroup").Elements("PackageReference")
+            .Where(p => (string?)p.Attribute("Include") == include).ToList();
+
+        if (refs.Count == 0)
+        {
+            var group = new XElement("ItemGroup",
+                new XElement("PackageReference",
+                    new XAttribute("Include", include),
+                    new XAttribute("Version", version)));
+            doc.Root.Add(group);
+        }
+        else
+        {
+            var first = refs[0];
+            var attr = first.Attribute("Version");
+            var elem = first.Element("Version");
+            if (attr != null) attr.Value = version;
+            else if (elem != null) elem.Value = version;
+            else first.Add(new XAttribute("Version", version));
+
+            foreach (var extra in refs.Skip(1).ToList()) extra.Remove();
+        }
+    }
+
+    static void EnsureProjectReference(XDocument doc, string include)
+    {
+        var refs = doc.Root!.Elements("ItemGroup").Elements("ProjectReference")
+            .Where(p => (string?)p.Attribute("Include") == include).ToList();
+        if (refs.Count == 0)
+        {
+            var group = doc.Root.Elements("ItemGroup").FirstOrDefault();
+            if (group == null)
+            {
+                group = new XElement("ItemGroup");
+                doc.Root.Add(group);
+            }
+            group.Add(new XElement("ProjectReference", new XAttribute("Include", include)));
+        }
+        else
+        {
+            foreach (var extra in refs.Skip(1).ToList()) extra.Remove();
+        }
+    }
+
+    static void UpdateApplicationProject(string solution, string basePath)
+    {
+        var appProj = Path.Combine(basePath, $"{solution}.Application", $"{solution}.Application.csproj");
+        if (!File.Exists(appProj)) return;
+
+        var doc = XDocument.Load(appProj);
+        var packages = doc.Root!.Elements("ItemGroup").Elements("PackageReference");
+
+        // remove DI-specific packages that shouldn't live in the Application project
+        foreach (var pr in packages.Where(p =>
+            {
+                var include = (string?)p.Attribute("Include");
+                return include == "MediatR.Extensions.Microsoft.DependencyInjection" ||
+                       include == "FluentValidation.DependencyInjectionExtensions";
+            }).ToList())
+        {
+            pr.Remove();
+        }
+
+        EnsurePackage(doc, "MediatR", MediatRVersion);
+        EnsurePackage(doc, "FluentValidation", FluentValidationVersion);
+
+        doc.Save(appProj);
+    }
+
+    static void UpdateInfrastructureProject(string solution, string basePath, string provider)
+    {
+        var infraProj = Path.Combine(basePath, $"{solution}.Infrastructure", $"{solution}.Infrastructure.csproj");
+        if (!File.Exists(infraProj)) return;
+
+        var doc = XDocument.Load(infraProj);
+
+        EnsurePackage(doc, "Microsoft.EntityFrameworkCore", EfCoreVersion);
+        EnsurePackage(doc, "Microsoft.EntityFrameworkCore.Design", EfCoreVersion);
+
+        var providerPackage = provider == "SQLite"
+            ? "Microsoft.EntityFrameworkCore.Sqlite"
+            : "Microsoft.EntityFrameworkCore.SqlServer";
+        EnsurePackage(doc, providerPackage, EfCoreVersion);
+        if (provider != "SQLite")
+            EnsurePackage(doc, "Microsoft.Data.SqlClient", SqlClientVersion);
+
+        doc.Save(infraProj);
+    }
+
+    static void UpdateApiProject(string solution, string provider, string basePath, string startupProject)
+    {
+        var apiProj = Path.Combine(basePath, startupProject, $"{startupProject}.csproj");
+        if (!File.Exists(apiProj)) return;
+
+        var doc = XDocument.Load(apiProj);
+
+        EnsurePackage(doc, "MediatR", MediatRVersion);
+        EnsurePackage(doc, "FluentValidation.DependencyInjectionExtensions", FluentValidationVersion);
+        EnsurePackage(doc, "Microsoft.AspNetCore.OpenApi", OpenApiVersion);
+        EnsurePackage(doc, "Swashbuckle.AspNetCore", SwaggerVersion);
+        EnsurePackage(doc, "Microsoft.EntityFrameworkCore.Design", EfCoreVersion);
+        foreach (var old in doc.Root!.Elements("ItemGroup").Elements("PackageReference")
+                     .Where(p => (string?)p.Attribute("Include") == "MediatR.Extensions.Microsoft.DependencyInjection").ToList())
+            old.Remove();
+        var providerPackage = provider == "SQLite"
+            ? "Microsoft.EntityFrameworkCore.Sqlite"
+            : "Microsoft.EntityFrameworkCore.SqlServer";
+        EnsurePackage(doc, providerPackage, EfCoreVersion);
+        if (provider != "SQLite")
+            EnsurePackage(doc, "Microsoft.Data.SqlClient", SqlClientVersion);
+
+        var rel = ".." + Path.DirectorySeparatorChar;
+        EnsureProjectReference(doc, $"{rel}{solution}.Application{Path.DirectorySeparatorChar}{solution}.Application.csproj");
+        EnsureProjectReference(doc, $"{rel}{solution}.Infrastructure{Path.DirectorySeparatorChar}{solution}.Infrastructure.csproj");
+
+        doc.Save(apiProj);
+    }
+
+    static void UpdateProgram(string solution, string provider, string entity, string basePath, string startupProject, string apiStyle)
+    {
+        var programFile = Path.Combine(basePath, startupProject, "Program.cs");
+        if (!File.Exists(programFile)) return;
+        var lines = File.ReadAllLines(programFile).ToList();
+
+        // remove leftover FluentValidation.AspNetCore references from template
+        lines.RemoveAll(l => l.Contains("FluentValidation.AspNetCore"));
+        lines.RemoveAll(l => l.Contains("AddFluentValidationAutoValidation"));
+        lines.RemoveAll(l => l.Contains("AddFluentValidationClientsideAdapters"));
+        // clean up malformed using lines that accidentally contain double dots
+        lines.RemoveAll(l => l.TrimStart().StartsWith("using ") && l.Contains(".."));
+        var usingLines = new List<string>
+        {
+            "using System;",
+            "using System.IO;",
+            "using MediatR;",
+            "using FluentValidation;",
+            $"using {solution}.Application;",
+            "using Microsoft.Extensions.DependencyInjection;"
+        };
+
+        if (!string.IsNullOrWhiteSpace(entity))
+        {
+            var plural = Naming.Pluralize(entity);
+            usingLines.Add("using Microsoft.EntityFrameworkCore;");
+            usingLines.Add($"using {solution}.Infrastructure.Persistence;");
+            usingLines.Add($"using {solution}.Core.Interfaces;");
+            usingLines.Add($"using {solution}.Infrastructure;");
+            usingLines.Add($"using {solution}.Core.Features.{plural};");
+            usingLines.Add($"using {solution}.Infrastructure.Features.{plural};");
+            if (apiStyle == "fast")
+                usingLines.Add($"using {startupProject}.Features.{plural};");
+        }
+
+        foreach (var u in usingLines)
+        {
+            if (!lines.Any(l => l.Trim() == u))
+                lines.Insert(0, u);
+        }
+        var idx = lines.FindIndex(l => l.Contains("var builder"));
+        if (idx >= 0)
+        {
+            var insertIndex = idx + 1;
+            if (!lines.Any(l => l.Contains("AddEndpointsApiExplorer")))
+                lines.Insert(insertIndex++, "builder.Services.AddEndpointsApiExplorer();");
+            if (!lines.Any(l => l.Contains("AddSwaggerGen")))
+                lines.Insert(insertIndex++, "builder.Services.AddSwaggerGen();");
+            if (apiStyle == "controller")
+            {
+                if (!lines.Any(l => l.Contains("AddControllers")))
+                    lines.Insert(insertIndex++, "builder.Services.AddControllers();");
+            }
+            else
+            {
+                lines.RemoveAll(l => l.Contains("AddControllers"));
+            }
+            if (!string.IsNullOrWhiteSpace(entity) && !lines.Any(l => l.Contains("AddDbContext<AppDbContext>")))
+            {
+                if (provider == "SQLite")
+                {
+                    var sqliteLines = new[]
+                    {
+                        $"var dbPath = Path.Combine(builder.Environment.ContentRootPath, \"..\", \"{solution}.Infrastructure\", \"Data\", \"app.db\");",
+                        "Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);",
+                        "builder.Services.AddDbContext<AppDbContext>(o => o.UseSqlite($\"Data Source={dbPath}\"));"
+                    };
+                    foreach (var l in sqliteLines)
+                        lines.Insert(insertIndex++, l);
+                }
+                else
+                {
+                    lines.Insert(insertIndex++, "builder.Services.AddDbContext<AppDbContext>(o => o.UseSqlServer(\"Server=.;Database=AppDb;Trusted_Connection=True;\"));");
+                }
+            }
+            if (!lines.Any(l => l.Contains("RegisterServicesFromAssemblyContaining<AssemblyMarker>")))
+                lines.Insert(insertIndex++, "builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<AssemblyMarker>());");
+            if (!lines.Any(l => l.Contains("AddValidatorsFromAssemblyContaining<AssemblyMarker>")))
+                lines.Insert(insertIndex++, "builder.Services.AddValidatorsFromAssemblyContaining<AssemblyMarker>();");
+            if (!string.IsNullOrWhiteSpace(entity))
+            {
+                if (!lines.Any(l => l.Contains($"AddScoped<I{entity}Repository, {entity}Repository>()")))
+                    lines.Insert(insertIndex++, $"builder.Services.AddScoped<I{entity}Repository, {entity}Repository>();");
+                if (!lines.Any(l => l.Contains("AddScoped<IUnitOfWork, UnitOfWork>()")))
+                    lines.Insert(insertIndex++, "builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();");
+            }
+        }
+
+        var buildIdx = lines.FindIndex(l => l.Contains("var app = builder.Build();"));
+        if (buildIdx >= 0 && !lines.Any(l => l.Contains("UseSwaggerUI()")))
+        {
+            var insertIndex = buildIdx + 1;
+            lines.Insert(insertIndex++, "if (app.Environment.IsDevelopment())");
+            lines.Insert(insertIndex++, "{");
+            lines.Insert(insertIndex++, "    app.UseSwagger();");
+            lines.Insert(insertIndex++, "    app.UseSwaggerUI();");
+            lines.Insert(insertIndex++, "}");
+        }
+        var runIdx = lines.FindIndex(l => l.Contains("app.Run();"));
+        if (runIdx >= 0)
+        {
+            if (apiStyle == "controller" && !lines.Any(l => l.Contains("app.MapControllers()")))
+                lines.Insert(runIdx++, "app.MapControllers();");
+            if (apiStyle == "fast")
+            {
+                lines.RemoveAll(l => l.Contains("app.MapControllers()"));
+                if (!string.IsNullOrWhiteSpace(entity) && !lines.Any(l => l.Contains($"app.Map{entity}Endpoints")))
+                    lines.Insert(runIdx++, $"app.Map{entity}Endpoints();");
+            }
+            if (!string.IsNullOrWhiteSpace(entity) && !lines.Any(l => l.Contains("Database.Migrate") || l.Contains("Database.EnsureCreated")))
+            {
+                var migrateLines = new List<string>
+                {
+                    "using (var scope = app.Services.CreateScope())",
+                    "{",
+                    "    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();",
+                    "    if (db.Database.GetPendingMigrations().Any())",
+                    "        db.Database.Migrate();",
+                    "    else",
+                    "        db.Database.EnsureCreated();",
+                    "}"
+                };
+                foreach (var ml in migrateLines)
+                {
+                    lines.Insert(runIdx++, ml);
+                }
+            }
+        }
+        File.WriteAllLines(programFile, lines);
+    }
+
+    static void RemoveTemplateFiles(string basePath, string startupProject)
+    {
+        var weather = Path.Combine(basePath, startupProject, "WeatherForecast.cs");
+        if (File.Exists(weather)) File.Delete(weather);
+        var controller = Path.Combine(basePath, startupProject, "Controllers", "WeatherForecastController.cs");
+        if (File.Exists(controller)) File.Delete(controller);
+
+        var program = Path.Combine(basePath, startupProject, "Program.cs");
+        if (File.Exists(program))
+        {
+            var lines = File.ReadAllLines(program).ToList();
+            var start = lines.FindIndex(l => l.Contains("var summaries"));
+            if (start >= 0)
+            {
+                var end = lines.FindIndex(start, l => l.Contains("GetWeatherForecast"));
+                if (end >= start)
+                    lines.RemoveRange(start, end - start + 1);
+            }
+            var recordIndex = lines.FindIndex(l => l.Contains("record WeatherForecast"));
+            if (recordIndex >= 0)
+            {
+                var closeIndex = lines.FindIndex(recordIndex, l => l.Trim() == "}");
+                if (closeIndex >= recordIndex)
+                    lines.RemoveRange(recordIndex, closeIndex - recordIndex + 1);
+            }
+            File.WriteAllLines(program, lines);
+        }
+    }
+}

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -153,6 +153,7 @@ public class ProjectUpdateStep : IScaffoldStep
             EnsurePackage(doc, "Microsoft.Data.SqlClient", SqlClientVersion);
 
         var rel = ".." + Path.DirectorySeparatorChar;
+        EnsureProjectReference(doc, $"{rel}{solution}.Core{Path.DirectorySeparatorChar}{solution}.Core.csproj");
         EnsureProjectReference(doc, $"{rel}{solution}.Application{Path.DirectorySeparatorChar}{solution}.Application.csproj");
         EnsureProjectReference(doc, $"{rel}{solution}.Infrastructure{Path.DirectorySeparatorChar}{solution}.Infrastructure.csproj");
 

--- a/Scaffolding/Steps/RepositoryStep.cs
+++ b/Scaffolding/Steps/RepositoryStep.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class RepositoryStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var plural = Naming.Pluralize(entity);
+        var commonDir = Path.Combine(basePath, $"{solution}.Core", "Common");
+        Directory.CreateDirectory(commonDir);
+        var pagedResultFile = Path.Combine(commonDir, "PagedResult.cs");
+        if (!File.Exists(pagedResultFile))
+        {
+            var pagedContent = """
+using System.Collections.Generic;
+
+namespace {{solution}}.Core.Common;
+
+public record PagedResult<T>(List<T> Items, int TotalCount, int Page, int PageSize);
+""";
+            File.WriteAllText(pagedResultFile, pagedContent.Replace("{{solution}}", solution));
+        }
+
+        var coreDir = Path.Combine(basePath, $"{solution}.Core", "Features", plural);
+        var legacyCoreDir = Path.Combine(basePath, $"{solution}.Core", plural);
+        var ifaceFile = Path.Combine(coreDir, $"I{entity}Repository.cs");
+        var legacyIface = Path.Combine(legacyCoreDir, $"I{entity}Repository.cs");
+        if (File.Exists(legacyIface) && !File.Exists(ifaceFile))
+        {
+            Directory.CreateDirectory(coreDir);
+            File.Move(legacyIface, ifaceFile);
+            if (Directory.Exists(legacyCoreDir) && Directory.GetFileSystemEntries(legacyCoreDir).Length == 0)
+                Directory.Delete(legacyCoreDir, true);
+        }
+        else
+        {
+            Directory.CreateDirectory(coreDir);
+        }
+        var ifaceTemplate = """
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using {{solution}}.Core.Common;
+
+namespace {{solution}}.Core.Features.{{entities}};
+
+public interface I{{entity}}Repository
+{
+    Task<{{entity}}?> GetByIdAsync(int id);
+    Task<List<{{entity}}>> GetAllAsync();
+    Task<PagedResult<{{entity}}>> ListAsync(int page = 1, int pageSize = 10);
+    Task AddAsync({{entity}} entity);
+    Task UpdateAsync({{entity}} entity);
+    Task DeleteAsync({{entity}} entity);
+}
+""";
+        var ifaceText = ifaceTemplate
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural);
+        if (!File.Exists(ifaceFile))
+        {
+            File.WriteAllText(ifaceFile, ifaceText);
+        }
+        else
+        {
+            var text = File.ReadAllText(ifaceFile);
+            if (!text.Contains("GetAllAsync"))
+            {
+                var insert = $@"    Task<{entity}?> GetByIdAsync(int id);
+    Task<List<{entity}>> GetAllAsync();
+    Task<PagedResult<{entity}>> ListAsync(int page = 1, int pageSize = 10);
+    Task AddAsync({entity} entity);
+    Task UpdateAsync({entity} entity);
+    Task DeleteAsync({entity} entity);
+";
+                var idx = text.LastIndexOf("}");
+                text = text.Insert(idx, insert);
+            }
+            if (!text.Contains("using " + solution + ".Core.Common;"))
+                text = "using " + solution + ".Core.Common;" + Environment.NewLine + text;
+            File.WriteAllText(ifaceFile, text);
+        }
+
+        var infraDir = Path.Combine(basePath, $"{solution}.Infrastructure", "Features", plural);
+        var legacyInfraDir = Path.Combine(basePath, $"{solution}.Infrastructure", plural);
+        var repoFile = Path.Combine(infraDir, $"{entity}Repository.cs");
+        var legacyRepo = Path.Combine(legacyInfraDir, $"{entity}Repository.cs");
+        if (File.Exists(legacyRepo) && !File.Exists(repoFile))
+        {
+            Directory.CreateDirectory(infraDir);
+            File.Move(legacyRepo, repoFile);
+            if (Directory.Exists(legacyInfraDir) && Directory.GetFileSystemEntries(legacyInfraDir).Length == 0)
+                Directory.Delete(legacyInfraDir, true);
+        }
+        else
+        {
+            Directory.CreateDirectory(infraDir);
+        }
+        var repoTemplate = """
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using {{solution}}.Core.Common;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Infrastructure.Persistence;
+
+namespace {{solution}}.Infrastructure.Features.{{entities}};
+
+public class {{entity}}Repository : I{{entity}}Repository
+{
+    private readonly AppDbContext _context;
+
+    public {{entity}}Repository(AppDbContext context) => _context = context;
+
+    public async Task AddAsync({{entity}} entity) => await _context.Set<{{entity}}>().AddAsync(entity);
+
+    public async Task DeleteAsync({{entity}} entity)
+    {
+        _context.Set<{{entity}}>().Remove(entity);
+        await Task.CompletedTask;
+    }
+
+    public async Task<{{entity}}?> GetByIdAsync(int id) => await _context.Set<{{entity}}>().FindAsync(id);
+
+    public async Task<List<{{entity}}>> GetAllAsync() => await _context.Set<{{entity}}>().ToListAsync();
+
+    public async Task<PagedResult<{{entity}}>> ListAsync(int page = 1, int pageSize = 10)
+    {
+        var query = _context.Set<{{entity}}>();
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        var total = await query.CountAsync();
+        return new PagedResult<{{entity}}>(items, total, page, pageSize);
+    }
+
+    public Task UpdateAsync({{entity}} entity)
+    {
+        _context.Set<{{entity}}>().Update(entity);
+        return Task.CompletedTask;
+    }
+}
+""";
+        var repoText = repoTemplate
+            .Replace("{{solution}}", solution)
+            .Replace("{{entity}}", entity)
+            .Replace("{{entities}}", plural);
+        if (!File.Exists(repoFile))
+        {
+            File.WriteAllText(repoFile, repoText);
+        }
+        else
+        {
+            var text = File.ReadAllText(repoFile);
+            if (!text.Contains("GetAllAsync"))
+            {
+                var methods = $@"    public async Task AddAsync({entity} entity) => await _context.Set<{entity}>().AddAsync(entity);
+
+    public async Task DeleteAsync({entity} entity)
+    {{
+        _context.Set<{entity}>().Remove(entity);
+        await Task.CompletedTask;
+    }}
+
+    public async Task<{entity}?> GetByIdAsync(int id) => await _context.Set<{entity}>().FindAsync(id);
+
+    public async Task<List<{entity}>> GetAllAsync() => await _context.Set<{entity}>().ToListAsync();
+
+    public async Task<PagedResult<{entity}>> ListAsync(int page = 1, int pageSize = 10)
+    {{
+        var query = _context.Set<{entity}>();
+        var items = await query.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+        var total = await query.CountAsync();
+        return new PagedResult<{entity}>(items, total, page, pageSize);
+    }}
+
+    public Task UpdateAsync({entity} entity)
+    {{
+        _context.Set<{entity}>().Update(entity);
+        return Task.CompletedTask;
+    }}
+";
+                var idx = text.LastIndexOf("}");
+                text = text.Insert(idx, methods);
+            }
+            var requiredUsings = new[]
+            {
+                "using System.Linq;",
+                "using System.Threading.Tasks;",
+                "using Microsoft.EntityFrameworkCore;",
+                "using System.Collections.Generic;",
+                "using " + solution + ".Core.Common;",
+                "using " + solution + ".Core.Features." + plural + ";",
+                "using " + solution + ".Infrastructure.Persistence;"
+            };
+            foreach (var u in requiredUsings)
+                if (!text.Contains(u))
+                    text = u + Environment.NewLine + text;
+            File.WriteAllText(repoFile, text);
+        }
+    }
+}

--- a/Scaffolding/Steps/UnitOfWorkStep.cs
+++ b/Scaffolding/Steps/UnitOfWorkStep.cs
@@ -1,0 +1,112 @@
+using System.IO;
+using System.Linq;
+using DotNetArch.Scaffolding;
+
+namespace DotNetArch.Scaffolding.Steps;
+
+public class UnitOfWorkStep : IScaffoldStep
+{
+    public void Execute(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var basePath = config.SolutionPath;
+        var plural = Naming.Pluralize(entity);
+        var coreDir = Path.Combine(basePath, $"{solution}.Core", "Interfaces");
+        Directory.CreateDirectory(coreDir);
+        var uowInterfaceFile = Path.Combine(coreDir, "IUnitOfWork.cs");
+        if (!File.Exists(uowInterfaceFile))
+        {
+            var iContent = """
+using System;
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+
+namespace {{solution}}.Core.Interfaces;
+
+public interface IUnitOfWork : IDisposable
+{
+    I{{entity}}Repository {{entity}}Repository { get; }
+    Task<int> SaveChangesAsync();
+}
+""";
+            File.WriteAllText(uowInterfaceFile, iContent
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural));
+        }
+        else
+        {
+            var lines = File.ReadAllLines(uowInterfaceFile).ToList();
+            var usingLine = $"using {solution}.Core.Features.{plural};";
+            if (!lines.Contains(usingLine))
+                lines.Insert(0, usingLine);
+            var propLine = $"    I{entity}Repository {entity}Repository {{ get; }}";
+            if (!lines.Any(l => l.Contains(propLine)))
+            {
+                var saveIdx = lines.FindIndex(l => l.Contains("SaveChangesAsync"));
+                lines.Insert(saveIdx, propLine);
+            }
+            File.WriteAllLines(uowInterfaceFile, lines);
+        }
+
+        var infraDir = Path.Combine(basePath, $"{solution}.Infrastructure");
+        Directory.CreateDirectory(infraDir);
+        var uowFile = Path.Combine(infraDir, "UnitOfWork.cs");
+        var lower = char.ToLowerInvariant(entity[0]) + entity.Substring(1);
+        if (!File.Exists(uowFile))
+        {
+            var uContent = """
+using System.Threading.Tasks;
+using {{solution}}.Core.Features.{{entities}};
+using {{solution}}.Core.Interfaces;
+using {{solution}}.Infrastructure.Persistence;
+using {{solution}}.Infrastructure.Features.{{entities}};
+
+namespace {{solution}}.Infrastructure;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly AppDbContext _context;
+    private I{{entity}}Repository? _{{lower}}Repository;
+
+    public UnitOfWork(AppDbContext context) => _context = context;
+
+    public I{{entity}}Repository {{entity}}Repository => _{{lower}}Repository ??= new {{entity}}Repository(_context);
+
+    public async Task<int> SaveChangesAsync() => await _context.SaveChangesAsync();
+
+    public void Dispose() => _context.Dispose();
+}
+""";
+            File.WriteAllText(uowFile, uContent
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural)
+                .Replace("{{lower}}", lower));
+        }
+        else
+        {
+            var lines = File.ReadAllLines(uowFile).ToList();
+            var usingDomain = $"using {solution}.Core.Features.{plural};";
+            var usingRepo = $"using {solution}.Infrastructure.Features.{plural};";
+            if (!lines.Contains(usingRepo)) lines.Insert(0, usingRepo);
+            if (!lines.Contains(usingDomain)) lines.Insert(0, usingDomain);
+
+            var fieldLine = $"    private I{entity}Repository? _{lower}Repository;";
+            if (!lines.Any(l => l.Contains(fieldLine)))
+            {
+                var contextIndex = lines.FindIndex(l => l.Contains("AppDbContext _context"));
+                lines.Insert(contextIndex + 1, fieldLine);
+            }
+
+            var propLine = $"    public I{entity}Repository {entity}Repository => _{lower}Repository ??= new {entity}Repository(_context);";
+            if (!lines.Any(l => l.Contains($"public I{entity}Repository {entity}Repository")))
+            {
+                var saveIdx = lines.FindIndex(l => l.Contains("SaveChangesAsync"));
+                lines.Insert(saveIdx, propLine);
+            }
+
+            File.WriteAllLines(uowFile, lines);
+        }
+    }
+}

--- a/SolutionConfig.cs
+++ b/SolutionConfig.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+public class SolutionConfig
+{
+    public string SolutionName { get; set; } = "";
+    public string SolutionPath { get; set; } = "";
+    public string StartupProject { get; set; } = "";
+    public string DatabaseProvider { get; set; } = "";
+    public string ApiStyle { get; set; } = "controller";
+
+    public Dictionary<string, EntityStatus> Entities { get; set; } = new();
+}
+
+public class EntityStatus
+{
+    public bool HasCrud { get; set; }
+    public bool HasAction { get; set; }
+}


### PR DESCRIPTION
## Summary
- run EF Core migrations for SQLite and other relational providers to ensure tables are created
- document that migrations run for SQL Server, SQLite and PostgreSQL while MongoDB skips
- ensure infrastructure project references EF Core provider packages so migrations compile

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b2542f4d08832385e6718b59e39779