### PR TITLE
fix: remove stray self-namespace in program update

### DIFF
--- a/ConfigManager.cs
+++ b/ConfigManager.cs
@@ -28,6 +28,8 @@ public static class ConfigManager
                 config.DatabaseProvider = value;
             else if (key.Equals("style", StringComparison.OrdinalIgnoreCase))
                 config.ApiStyle = value;
+            else if (key.Equals("os", StringComparison.OrdinalIgnoreCase))
+                config.Os = value;
             else if (key.StartsWith("entity.", StringComparison.OrdinalIgnoreCase))
             {
                 var name = key.Substring("entity.".Length);
@@ -55,6 +57,8 @@ public static class ConfigManager
             $"path: {config.SolutionPath}{nl}" +
             $"startup: {config.StartupProject}{nl}" +
             $"style: {config.ApiStyle}{nl}";
+        if (!string.IsNullOrWhiteSpace(config.Os))
+            content += $"os: {config.Os}{nl}";
         if (!string.IsNullOrWhiteSpace(config.DatabaseProvider))
             content += $"database: {config.DatabaseProvider}{nl}";
         foreach (var kv in config.Entities)

--- a/Main.cs
+++ b/Main.cs
@@ -77,7 +77,7 @@ class Program
             }
 
             if (isCommand == null)
-                isCommand = Ask("Is command? (true/false)", "true").ToLower() != "false";
+                isCommand = Ask("Is command? (y/n)", "y").Trim().ToLower().StartsWith("y");
             if (string.IsNullOrWhiteSpace(outputPath))
                 outputPath = Ask("Output path", Directory.GetCurrentDirectory());
 

--- a/Main.cs
+++ b/Main.cs
@@ -220,7 +220,10 @@ class Program
         RunCommand($"dotnet add {solutionName}.API/{solutionName}.API.csproj reference {solutionName}.Infrastructure/{solutionName}.Infrastructure.csproj");
 
         var provider = DatabaseProviderSelector.Choose();
-        var config = new SolutionConfig { SolutionName = solutionName, SolutionPath = solutionDir, StartupProject = startupProject, DatabaseProvider = provider, ApiStyle = apiStyle };
+        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" :
+                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx" :
+                 RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" : "unknown";
+        var config = new SolutionConfig { SolutionName = solutionName, SolutionPath = solutionDir, StartupProject = startupProject, DatabaseProvider = provider, ApiStyle = apiStyle, Os = os };
         ConfigManager.Save(solutionDir, config);
         new ProjectUpdateStep().Execute(config, string.Empty);
 

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -172,6 +172,9 @@ public class ProjectUpdateStep : IScaffoldStep
         lines.RemoveAll(l => l.Contains("AddFluentValidationClientsideAdapters"));
         // clean up malformed using lines that accidentally contain double dots
         lines.RemoveAll(l => l.TrimStart().StartsWith("using ") && l.Contains(".."));
+        // remove stray self-referencing namespace imports left by templates
+        lines.RemoveAll(l => l.Trim() == $"using {solution};");
+        lines.RemoveAll(l => l.Trim() == $"using {startupProject};");
         var usingLines = new List<string>
         {
             "using System;",

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -177,11 +177,8 @@ public class ProjectUpdateStep : IScaffoldStep
         lines.RemoveAll(l => l.TrimStart().StartsWith("using ") && l.Contains(".."));
         // remove stray self-referencing namespace imports left by templates
         lines.RemoveAll(l =>
-        {
-            var collapsed = Regex.Replace(l, @"\s+", "");
-            return collapsed.Equals($"using{solution};", StringComparison.Ordinal) ||
-                   collapsed.Equals($"using{startupProject};", StringComparison.Ordinal);
-        });
+            Regex.IsMatch(l, $@"^\s*(global\s+)?using\s+{Regex.Escape(solution)}\s*;" ) ||
+            Regex.IsMatch(l, $@"^\s*(global\s+)?using\s+{Regex.Escape(startupProject)}\s*;" ));
         var usingLines = new List<string>
         {
             "using System;",

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -173,8 +173,8 @@ public class ProjectUpdateStep : IScaffoldStep
         // clean up malformed using lines that accidentally contain double dots
         lines.RemoveAll(l => l.TrimStart().StartsWith("using ") && l.Contains(".."));
         // remove stray self-referencing namespace imports left by templates
-        lines.RemoveAll(l => l.Trim() == $"using {solution};");
-        lines.RemoveAll(l => l.Trim() == $"using {startupProject};");
+        lines.RemoveAll(l => Regex.IsMatch(l.Trim(), $@"^using\s+{Regex.Escape(solution)}\s*;"));
+        lines.RemoveAll(l => Regex.IsMatch(l.Trim(), $@"^using\s+{Regex.Escape(startupProject)}\s*;"));
         var usingLines = new List<string>
         {
             "using System;",

--- a/SolutionConfig.cs
+++ b/SolutionConfig.cs
@@ -7,6 +7,7 @@ public class SolutionConfig
     public string StartupProject { get; set; } = "";
     public string DatabaseProvider { get; set; } = "";
     public string ApiStyle { get; set; } = "controller";
+    public string Os { get; set; } = "";
 
     public Dictionary<string, EntityStatus> Entities { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- remove leftover `using {solution};` and `using {startupProject};` imports when updating Program.cs

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b4bcd1725483239e9a2a3eb1e86590