### PR TITLE
Call ApplicationStep during solution generation

### DIFF
--- a/ActionScaffolder.cs
+++ b/ActionScaffolder.cs
@@ -351,7 +351,7 @@ public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entit
                 "        {",
                 $"            await mediator.Send(new {Upper(action)}{entity}Command(entity));",
                 "            return Results.Ok();",
-                $"        }).WithTags(\"{entity}\");",
+                $"        }}).WithTags(\"{entity}\");",
             };
             lines.InsertRange(insertIndex, method);
         }

--- a/ActionScaffolder.cs
+++ b/ActionScaffolder.cs
@@ -341,8 +341,8 @@ public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entit
             lines.Insert(lastUsing + 1, usingLine);
 
         var classClose = lines.FindLastIndex(l => l.Trim() == "}");
-        var methodClose = lines.FindLastIndex(classClose - 1, l => l.Trim() == "    }");
-        var insertIndex = methodClose;
+        var methodClose = lines.FindLastIndex(classClose - 1, l => l.Trim() == "}");
+        var insertIndex = methodClose < 0 ? classClose : methodClose;
         if (isCommand)
         {
             var method = new[]

--- a/ActionScaffolder.cs
+++ b/ActionScaffolder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
 using DotNetArch.Scaffolding;
 using DotNetArch.Scaffolding.Steps;
 
@@ -42,7 +43,10 @@ static class ActionScaffolder
 
         AddRepositoryMethod(config, entity, action, isCommand);
         AddApplicationFiles(config, entity, action, isCommand);
-        AddControllerMethod(config, entity, action, isCommand);
+        if (config.ApiStyle.Equals("fast", StringComparison.OrdinalIgnoreCase))
+            AddEndpointMethod(config, entity, action, isCommand);
+        else
+            AddControllerMethod(config, entity, action, isCommand);
 
         if (!provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
         {
@@ -302,6 +306,66 @@ public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entit
 }
 """));
         }
+    }
+
+    static void AddEndpointMethod(SolutionConfig config, string entity, string action, bool isCommand)
+    {
+        var solution = config.SolutionName;
+        var startupProject = config.StartupProject;
+        var plural = Naming.Pluralize(entity);
+        var apiDir = Path.Combine(config.SolutionPath, startupProject, "Features", plural);
+        Directory.CreateDirectory(apiDir);
+        var file = Path.Combine(apiDir, $"{entity}Endpoints.cs");
+        var lines = File.Exists(file)
+            ? File.ReadAllLines(file).ToList()
+            : new List<string>
+            {
+                "using MediatR;",
+                "using Microsoft.AspNetCore.Builder;",
+                "using Microsoft.AspNetCore.Http;",
+                $"using {solution}.Core.Features.{plural};",
+                "",
+                $"namespace {startupProject}.Features.{plural};",
+                "",
+                $"public static class {entity}Endpoints",
+                "{",
+                $"    public static void Map{entity}Endpoints(this IEndpointRouteBuilder routes)",
+                "    {",
+                "    }",
+                "}",
+            };
+
+        var usingLine = $"using {solution}.Application.Features.{plural}.{(isCommand ? "Commands" : "Queries")}.{Upper(action)};";
+        var lastUsing = lines.FindLastIndex(l => l.StartsWith("using "));
+        if (!lines.Any(l => l.Trim() == usingLine))
+            lines.Insert(lastUsing + 1, usingLine);
+
+        var classClose = lines.FindLastIndex(l => l.Trim() == "}");
+        var methodClose = lines.FindLastIndex(classClose - 1, l => l.Trim() == "    }");
+        var insertIndex = methodClose;
+        if (isCommand)
+        {
+            var method = new[]
+            {
+                $"        routes.MapPost(\"/Api/{entity}/{Upper(action)}\", async (IMediator mediator, {entity} entity) =>",
+                "        {",
+                $"            await mediator.Send(new {Upper(action)}{entity}Command(entity));",
+                "            return Results.Ok();",
+                "        });",
+            };
+            lines.InsertRange(insertIndex, method);
+        }
+        else
+        {
+            var method = new[]
+            {
+                $"        routes.MapGet(\"/Api/{entity}/{Upper(action)}/{{id}}\", async (IMediator mediator, int id) =>",
+                $"            await mediator.Send(new {Upper(action)}{entity}Query(id)) is {entity} result ? Results.Ok(result) : Results.NotFound());",
+            };
+            lines.InsertRange(insertIndex, method);
+        }
+
+        File.WriteAllLines(file, lines);
     }
 
     static void AddControllerMethod(SolutionConfig config, string entity, string action, bool isCommand)

--- a/ActionScaffolder.cs
+++ b/ActionScaffolder.cs
@@ -351,7 +351,7 @@ public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entit
                 "        {",
                 $"            await mediator.Send(new {Upper(action)}{entity}Command(entity));",
                 "            return Results.Ok();",
-                "        });",
+                $"        }).WithTags(\"{entity}\");",
             };
             lines.InsertRange(insertIndex, method);
         }
@@ -360,7 +360,8 @@ public class {{action}}{{entity}}Validator : AbstractValidator<{{action}}{{entit
             var method = new[]
             {
                 $"        routes.MapGet(\"/Api/{entity}/{Upper(action)}/{{id}}\", async (IMediator mediator, int id) =>",
-                $"            await mediator.Send(new {Upper(action)}{entity}Query(id)) is {entity} result ? Results.Ok(result) : Results.NotFound());",
+                $"            await mediator.Send(new {Upper(action)}{entity}Query(id)) is {entity} result ? Results.Ok(result) : Results.NotFound())",
+                $"            .WithTags(\"{entity}\");",
             };
             lines.InsertRange(insertIndex, method);
         }

--- a/Main.cs
+++ b/Main.cs
@@ -77,7 +77,7 @@ class Program
             }
 
             if (isCommand == null)
-                isCommand = Ask("Is command? (true/false)", "true").ToLower() != "false";
+                isCommand = AskYesNo("Is command?", true);
             if (string.IsNullOrWhiteSpace(outputPath))
                 outputPath = Ask("Output path", Directory.GetCurrentDirectory());
 
@@ -140,6 +140,23 @@ class Program
         Console.Write($"{message}{(defaultValue != null ? $" [{defaultValue}]" : "")}: ");
         var input = Console.ReadLine();
         return string.IsNullOrWhiteSpace(input) ? (defaultValue ?? string.Empty) : input;
+    }
+
+    static bool AskYesNo(string message, bool defaultYes)
+    {
+        var def = defaultYes ? "y" : "n";
+        while (true)
+        {
+            Console.Write($"{message} (y/n) [{def}]: ");
+            var input = Console.ReadLine()?.Trim().ToLower();
+            if (string.IsNullOrEmpty(input))
+                return defaultYes;
+            if (input == "y" || input == "yes")
+                return true;
+            if (input == "n" || input == "no")
+                return false;
+            Console.WriteLine("Please enter 'y' or 'n'.");
+        }
     }
 
     static string AskOption(string message, string[] options, int defaultIndex = 0)

--- a/Main.cs
+++ b/Main.cs
@@ -222,6 +222,7 @@ class Program
         var provider = DatabaseProviderSelector.Choose();
         var config = new SolutionConfig { SolutionName = solutionName, SolutionPath = solutionDir, StartupProject = startupProject, DatabaseProvider = provider, ApiStyle = apiStyle };
         ConfigManager.Save(solutionDir, config);
+        new ApplicationStep().Execute(config, string.Empty);
         new ProjectUpdateStep().Execute(config, string.Empty);
 
         Console.WriteLine();

--- a/Scaffolding/Steps/ApplicationStep.cs
+++ b/Scaffolding/Steps/ApplicationStep.cs
@@ -19,6 +19,8 @@ public class ApplicationStep : IScaffoldStep
             var markerContent = $"namespace {solution}.Application;{Environment.NewLine}{Environment.NewLine}public class AssemblyMarker {{ }}{Environment.NewLine}";
             File.WriteAllText(marker, markerContent);
         }
+        if (string.IsNullOrWhiteSpace(entity))
+            return;
         var appBase = Path.Combine(appRoot, "Features", plural);
         Directory.CreateDirectory(appBase);
 

--- a/Scaffolding/Steps/MinimalApiStep.cs
+++ b/Scaffolding/Steps/MinimalApiStep.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
+using System.Linq;
 using DotNetArch.Scaffolding;
 
 namespace DotNetArch.Scaffolding.Steps;
@@ -15,8 +17,9 @@ public class MinimalApiStep : IScaffoldStep
         var apiDir = Path.Combine(basePath, startupProject, "Features", plural);
         Directory.CreateDirectory(apiDir);
         var file = Path.Combine(apiDir, $"{entity}Endpoints.cs");
-        if (File.Exists(file)) return;
-        var content = """
+        if (!File.Exists(file))
+        {
+            var content = """
 using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -68,10 +71,72 @@ public static class {{entity}}Endpoints
     }
 }
 """;
-        File.WriteAllText(file, content
-            .Replace("{{solution}}", solution)
-            .Replace("{{entity}}", entity)
-            .Replace("{{entities}}", plural)
-            .Replace("{{startupProject}}", startupProject));
+            File.WriteAllText(file, content
+                .Replace("{{solution}}", solution)
+                .Replace("{{entity}}", entity)
+                .Replace("{{entities}}", plural)
+                .Replace("{{startupProject}}", startupProject));
+            return;
+        }
+
+        var lines = File.ReadAllLines(file).ToList();
+        var lastUsing = lines.FindLastIndex(l => l.StartsWith("using "));
+        void EnsureUsing(string ns)
+        {
+            var statement = $"using {ns};";
+            if (!lines.Any(l => l.Trim() == statement))
+                lines.Insert(++lastUsing, statement);
+        }
+
+        EnsureUsing($"{solution}.Application.Features.{plural}.Commands.Create");
+        EnsureUsing($"{solution}.Application.Features.{plural}.Commands.Update");
+        EnsureUsing($"{solution}.Application.Features.{plural}.Commands.Delete");
+        EnsureUsing($"{solution}.Application.Features.{plural}.Queries.GetById");
+        EnsureUsing($"{solution}.Application.Features.{plural}.Queries.GetAll");
+        EnsureUsing($"{solution}.Application.Features.{plural}.Queries.GetList");
+        EnsureUsing($"{solution}.Core.Common");
+
+        if (!lines.Any(l => l.Contains($"Get{entity}ByIdQuery")))
+        {
+            var classClose = lines.FindLastIndex(l => l.Trim() == "}");
+            var methodClose = lines.FindLastIndex(classClose - 1, l => l.Trim() == "}");
+            var insertIndex = methodClose < 0 ? classClose : methodClose;
+            var crudLines = new[]
+            {
+                $"        routes.MapGet(\"/Api/{entity}/{{id}}\", async (IMediator mediator, int id) =>",
+                $"            await mediator.Send(new Get{entity}ByIdQuery(id)) is {entity} result ? Results.Ok(result) : Results.NotFound())",
+                $"            .WithTags(\"{entity}\");",
+                "",
+                $"        routes.MapGet(\"/Api/{entity}/All\", async (IMediator mediator) =>",
+                $"            Results.Ok(await mediator.Send(new Get{entity}AllQuery())))",
+                $"            .WithTags(\"{entity}\");",
+                "",
+                $"        routes.MapGet(\"/Api/{entity}/List\", async (IMediator mediator, int page, int pageSize) =>",
+                $"            Results.Ok(await mediator.Send(new Get{entity}ListQuery(page, pageSize))))",
+                $"            .WithTags(\"{entity}\");",
+                "",
+                $"        routes.MapPost(\"/Api/{entity}\", async (IMediator mediator, {entity} entity) =>",
+                "        {",
+                $"            var created = await mediator.Send(new Create{entity}Command(entity));",
+                $"            return Results.Created($\"/Api/{entity}/{{created.Id}}\", created);",
+                $"        }).WithTags(\"{entity}\");",
+                "",
+                $"        routes.MapPut(\"/Api/{entity}/{{id}}\", async (IMediator mediator, int id, {entity} entity) =>",
+                "        {",
+                $"            entity.Id = id;",
+                $"            await mediator.Send(new Update{entity}Command(entity));",
+                $"            return Results.NoContent();",
+                $"        }).WithTags(\"{entity}\");",
+                "",
+                $"        routes.MapDelete(\"/Api/{entity}/{{id}}\", async (IMediator mediator, int id) =>",
+                "        {",
+                $"            await mediator.Send(new Delete{entity}Command(id));",
+                $"            return Results.NoContent();",
+                $"        }).WithTags(\"{entity}\");",
+            };
+            lines.InsertRange(insertIndex, crudLines);
+        }
+
+        File.WriteAllLines(file, lines);
     }
 }

--- a/Scaffolding/Steps/MinimalApiStep.cs
+++ b/Scaffolding/Steps/MinimalApiStep.cs
@@ -119,20 +119,20 @@ public static class {{entity}}Endpoints
                 "        {",
                 $"            var created = await mediator.Send(new Create{entity}Command(entity));",
                 $"            return Results.Created($\"/Api/{entity}/{{created.Id}}\", created);",
-                $"        }).WithTags(\"{entity}\");",
+                $"        }}).WithTags(\"{entity}\");",
                 "",
                 $"        routes.MapPut(\"/Api/{entity}/{{id}}\", async (IMediator mediator, int id, {entity} entity) =>",
                 "        {",
                 $"            entity.Id = id;",
                 $"            await mediator.Send(new Update{entity}Command(entity));",
                 $"            return Results.NoContent();",
-                $"        }).WithTags(\"{entity}\");",
+                $"        }}).WithTags(\"{entity}\");",
                 "",
                 $"        routes.MapDelete(\"/Api/{entity}/{{id}}\", async (IMediator mediator, int id) =>",
                 "        {",
                 $"            await mediator.Send(new Delete{entity}Command(id));",
                 $"            return Results.NoContent();",
-                $"        }).WithTags(\"{entity}\");",
+                $"        }}).WithTags(\"{entity}\");",
             };
             lines.InsertRange(insertIndex, crudLines);
         }

--- a/Scaffolding/Steps/MinimalApiStep.cs
+++ b/Scaffolding/Steps/MinimalApiStep.cs
@@ -36,32 +36,35 @@ public static class {{entity}}Endpoints
     public static void Map{{entity}}Endpoints(this IEndpointRouteBuilder routes)
     {
         routes.MapGet("/Api/{{entity}}/{id}", async (IMediator mediator, int id) =>
-            await mediator.Send(new Get{{entity}}ByIdQuery(id)) is {{entity}} result ? Results.Ok(result) : Results.NotFound());
+            await mediator.Send(new Get{{entity}}ByIdQuery(id)) is {{entity}} result ? Results.Ok(result) : Results.NotFound())
+            .WithTags("{{entity}}");
 
         routes.MapGet("/Api/{{entity}}/All", async (IMediator mediator) =>
-            Results.Ok(await mediator.Send(new Get{{entity}}AllQuery())));
+            Results.Ok(await mediator.Send(new Get{{entity}}AllQuery())))
+            .WithTags("{{entity}}");
 
         routes.MapGet("/Api/{{entity}}/List", async (IMediator mediator, int page, int pageSize) =>
-            Results.Ok(await mediator.Send(new Get{{entity}}ListQuery(page, pageSize))));
+            Results.Ok(await mediator.Send(new Get{{entity}}ListQuery(page, pageSize))))
+            .WithTags("{{entity}}");
 
         routes.MapPost("/Api/{{entity}}", async (IMediator mediator, {{entity}} entity) =>
         {
             var created = await mediator.Send(new Create{{entity}}Command(entity));
             return Results.Created($"/Api/{{entity}}/{created.Id}", created);
-        });
+        }).WithTags("{{entity}}");
 
         routes.MapPut("/Api/{{entity}}/{id}", async (IMediator mediator, int id, {{entity}} entity) =>
         {
             entity.Id = id;
             await mediator.Send(new Update{{entity}}Command(entity));
             return Results.NoContent();
-        });
+        }).WithTags("{{entity}}");
 
         routes.MapDelete("/Api/{{entity}}/{id}", async (IMediator mediator, int id) =>
         {
             await mediator.Send(new Delete{{entity}}Command(id));
             return Results.NoContent();
-        });
+        }).WithTags("{{entity}}");
     }
 }
 """;


### PR DESCRIPTION
## Summary
- Avoid scaffolding feature folders when no entity is provided to `ApplicationStep`
- Generate assembly marker at solution creation time

## Testing
- `dotnet build` *(fails: current SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c71d73d0832397c84f6a5b1c2106