### PR TITLE
Default API startup and remember solution path

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -189,8 +189,12 @@ class Program
                     return;
                 }
                 var prev = migrations.Length > 1 ? migrations[migrations.Length - 2] : "0";
-                RunCommand($"dotnet ef database update {prev} --project {infraProj} --startup-project {startProj}", basePath);
-                RunCommand($"dotnet ef migrations remove --project {infraProj} --startup-project {startProj}", basePath);
+                if (!RunCommand($"dotnet ef database update {prev} --project {infraProj} --startup-project {startProj}", basePath))
+                {
+                    Error("Failed to rollback database; migration removal aborted.");
+                    return;
+                }
+                RunCommand($"dotnet ef migrations remove --force --project {infraProj} --startup-project {startProj}", basePath);
             }
             else
             {

--- a/Main.cs
+++ b/Main.cs
@@ -114,7 +114,10 @@ class Program
             }
 
             var provider = config.DatabaseProvider;
-            if (!string.IsNullOrWhiteSpace(provider) && !provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
+            var checkMigrations = AskYesNo(
+                "Check for entity changes and apply migrations before running?",
+                false);
+            if (checkMigrations && !string.IsNullOrWhiteSpace(provider) && !provider.Equals("Mongo", StringComparison.OrdinalIgnoreCase))
             {
                 if (!EnsureEfTool(basePath))
                     return;

--- a/Main.cs
+++ b/Main.cs
@@ -33,7 +33,7 @@ class Program
             }
 
             if (string.IsNullOrWhiteSpace(outputPath))
-                outputPath = Ask("Output path", Directory.GetCurrentDirectory());
+                outputPath = PathState.Load() ?? Directory.GetCurrentDirectory();
 
             var basePath = outputPath!;
             var config = ConfigManager.Load(basePath);
@@ -79,7 +79,7 @@ class Program
             if (isCommand == null)
                 isCommand = AskYesNo("Is command?", true);
             if (string.IsNullOrWhiteSpace(outputPath))
-                outputPath = Ask("Output path", Directory.GetCurrentDirectory());
+                outputPath = PathState.Load() ?? Directory.GetCurrentDirectory();
 
             var basePath = outputPath!;
             var config = ConfigManager.Load(basePath);
@@ -122,7 +122,7 @@ class Program
             if (string.IsNullOrWhiteSpace(outputPath))
                 outputPath = Ask("Output path", Directory.GetCurrentDirectory());
             if (string.IsNullOrWhiteSpace(startup))
-                startup = Ask("Startup project", $"{solutionName}.API");
+                startup = $"{solutionName}.API";
             if (string.IsNullOrWhiteSpace(style))
                 style = AskOption("Select API style", new[] { "controller", "fast" }).ToLower();
             if (string.IsNullOrWhiteSpace(style))
@@ -200,7 +200,7 @@ class Program
         }
 
         var outputPath = Ask("Enter output path", Directory.GetCurrentDirectory());
-        var startup = Ask("Startup project", $"{solutionName}.API");
+        var startup = $"{solutionName}.API";
         var style = AskOption("Select API style", new[] { "controller", "fast" }).ToLower();
         if (string.IsNullOrWhiteSpace(style)) style = "controller";
 
@@ -239,6 +239,7 @@ class Program
         var provider = DatabaseProviderSelector.Choose();
         var config = new SolutionConfig { SolutionName = solutionName, SolutionPath = solutionDir, StartupProject = startupProject, DatabaseProvider = provider, ApiStyle = apiStyle };
         ConfigManager.Save(solutionDir, config);
+        PathState.Save(solutionDir);
         new ApplicationStep().Execute(config, string.Empty);
         new ProjectUpdateStep().Execute(config, string.Empty);
 

--- a/PathState.cs
+++ b/PathState.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+public static class PathState
+{
+    private const string FileName = ".dotnet-arch-state";
+
+    public static void Save(string solutionPath)
+    {
+        var file = GetFile();
+        File.WriteAllText(file, solutionPath);
+    }
+
+    public static string? Load()
+    {
+        var file = GetFile();
+        if (!File.Exists(file))
+            return null;
+        return File.ReadAllText(file).Trim();
+    }
+
+    private static string GetFile()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, FileName);
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -121,7 +121,7 @@ dotnet-arch update migration [--output=Path]
 dotnet-arch remove migration [--output=Path]
 ```
 
-`update migration` checks for entity changes, generates a timestamped migration if necessary, and updates the database. `remove migration` deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path.
+`update migration` rebuilds the most recent migration: it rolls the database back to the previous migration, removes the last migration, and then regenerates it. `remove migration` rolls back the database to the previous state and deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path.
 
 ---
 
@@ -195,8 +195,8 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
 - **`exec` command**: Run the startup project with an optional migration check that can generate and apply pending EF Core migrations.
-- **`update migration` command**: Check for entity changes, create a new migration if needed, and update the database.
-- **`remove migration` command**: Delete the most recent EF Core migration.
+- **`update migration` command**: Rebuild the most recent migration by rolling back the database, removing the last migration, and regenerating it.
+- **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.
 - **Custom output path**: Commands remember the last solution path but accept an `--output` option so code can be generated in test directories or alternative locations.

--- a/README.MD
+++ b/README.MD
@@ -102,6 +102,16 @@ dotnet-arch new action --entity=EntityName --action=getfile --is-command=false -
 
 The tool generates the command or query, handler, validator, repository method, and controller endpoint for the specified action. If the entity slice is missing, a minimal repository and controller are also created with only this action stub. Migrations are applied automatically after scaffolding so the database stays in sync.
 
+#### Run the Startup Project
+
+After scaffolding, launch the API with automatic EF Core migrations:
+
+```
+dotnet-arch exec [--output=Path]
+```
+
+This checks for model changes, creates a new migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
+
 ---
 
 #### **How to Clone and Run the Project**
@@ -173,12 +183,13 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
+- **`exec` command**: Run the startup project while automatically generating and applying pending EF Core migrations.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.
 - **Custom output path**: Both `new solution` and `new crud` accept an `--output` option so code can be generated in test directories or alternative locations.
 - **Development Swagger setup**: API projects automatically reference `Microsoft.AspNetCore.OpenApi` and `Swashbuckle.AspNetCore`, register Swagger services, and enable Swagger UI in development while removing default template files and sample endpoints.
 - **Feature-based folder structure**: Each layer organizes code under `Features/<Entity>` so all slices stay grouped.
-  - **Automatic migrations**: `new crud` and `new action` verify `dotnet-ef` and attempt installation if needed. For relational providers (SQL Server, SQLite, PostgreSQL) migrations and database updates run automatically; for MongoDB the process skips migrations. Generated `Program.cs` calls `Database.Migrate()` on startup to apply any pending migrations so new tables are created automatically.
+  - **Automatic migrations**: `new crud`, `new action`, and `exec` verify `dotnet-ef` and attempt installation if needed. For relational providers (SQL Server, SQLite, PostgreSQL) migrations and database updates run automatically; for MongoDB the process skips migrations. Generated `Program.cs` calls `Database.Migrate()` on startup to apply any pending migrations so new tables are created automatically.
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -117,11 +117,10 @@ When run, the command asks whether to check for model changes. Choosing **y** cr
 Work with EF Core migrations without starting the application:
 
 ```bash
-dotnet-arch update migration [Name] [--output=Path]
 dotnet-arch remove migration [--output=Path]
 ```
 
-`update migration` rebuilds the most recent migration: it rolls the database back to the previous migration, removes the last migration, and then regenerates it with the supplied `Name`. If no name is provided on the command line the tool will prompt for one to avoid placeholder names. `remove migration` rolls back the database to the previous state and deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path, and they automatically pass `--project`, `--startup-project`, and migration folder arguments to `dotnet ef` so you don't have to.
+`remove migration` rolls the database back to the previous state and deletes the most recent migration. The command accepts an optional `--output` to override the stored solution path and automatically supplies `--project`, `--startup-project`, and migration folder arguments to `dotnet ef` so you don't have to.
 
 ---
 
@@ -195,7 +194,6 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
 - **`exec` command**: Run the startup project with an optional migration check that can generate and apply pending EF Core migrations.
-- **`update migration` command**: Rebuild the most recent migration by rolling back the database, removing the last migration, and regenerating it.
 - **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.

--- a/README.MD
+++ b/README.MD
@@ -117,11 +117,11 @@ When run, the command asks whether to check for model changes. Choosing **y** cr
 Work with EF Core migrations without starting the application:
 
 ```bash
-dotnet-arch update migration [--output=Path]
+dotnet-arch update migration [Name] [--output=Path]
 dotnet-arch remove migration [--output=Path]
 ```
 
-`update migration` rebuilds the most recent migration: it rolls the database back to the previous migration, removes the last migration, and then regenerates it. `remove migration` rolls back the database to the previous state and deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path.
+`update migration` rebuilds the most recent migration: it rolls the database back to the previous migration, removes the last migration, and then regenerates it with the supplied `Name`. If no name is provided on the command line the tool will prompt for one to avoid placeholder names. `remove migration` rolls back the database to the previous state and deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path, and they automatically pass `--project`, `--startup-project`, and migration folder arguments to `dotnet ef` so you don't have to.
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -167,6 +167,7 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Ease of Use**: Intuitive and straightforward CLI commands.
 - **`new crud` scaffolding**: Generates vertical-slice CQRS CRUD with MediatR, FluentValidation, EF Core repositories, and paginated results.
 - **Database Provider Selection**: Choose between SQL Server, SQLite, PostgreSQL or MongoDB (default SQLite); the selected provider is stored so future runs don't prompt again.
+  - *Other providers are experimental and require more testing and development before a NuGet release.*
 - **Idempotent Generation**: Re-running commands updates existing files without creating duplicates.
 - **Repository & Unit of Work patterns**: Each entity gets its own repository and UoW registration for clean data access.
 - **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.

--- a/README.MD
+++ b/README.MD
@@ -112,6 +112,17 @@ dotnet-arch exec [--output=Path]
 
 When run, the command asks whether to check for model changes. Choosing **y** creates a migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
 
+#### Manage Migrations
+
+Work with EF Core migrations without starting the application:
+
+```bash
+dotnet-arch update migration [--output=Path]
+dotnet-arch remove migration [--output=Path]
+```
+
+`update migration` checks for entity changes, generates a timestamped migration if necessary, and updates the database. `remove migration` deletes the most recent migration. Both commands accept an optional `--output` to override the stored solution path.
+
 ---
 
 #### **How to Clone and Run the Project**
@@ -184,6 +195,8 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
 - **`exec` command**: Run the startup project with an optional migration check that can generate and apply pending EF Core migrations.
+- **`update migration` command**: Check for entity changes, create a new migration if needed, and update the database.
+- **`remove migration` command**: Delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.
 - **Custom output path**: Commands remember the last solution path but accept an `--output` option so code can be generated in test directories or alternative locations.

--- a/README.MD
+++ b/README.MD
@@ -68,7 +68,7 @@ After creating a solution you can scaffold a full CRUD vertical slice for an ent
 dotnet-arch new crud --entity=EntityName [--output=Path]
 ```
 
-`--output` points to the solution directory; if omitted, the current directory is used. If required arguments are missing the CLI prompts for them. The command reads `dotnet-arch.yml` to locate the solution name and scaffolds the entity slice. Depending on the selected style it creates either API controllers or minimal FastAPI endpoints along with domain models, repositories, unit of work, MediatR handlers and validators. The CLI installs `dotnet-ef` if needed and runs migrations for relational providers (SQL Server, SQLite, PostgreSQL) so schema changes are applied automatically. Each entity is placed under a `Features/<Entity>` folder in every layer and follows a CQRS-aware vertical slice:
+`--output` points to the solution directory; if omitted, the last path saved by the tool is used (falling back to the current directory). If required arguments are missing the CLI prompts for them. The command reads `dotnet-arch.yml` to locate the solution name and scaffolds the entity slice. Depending on the selected style it creates either API controllers or minimal FastAPI endpoints along with domain models, repositories, unit of work, MediatR handlers and validators. The CLI installs `dotnet-ef` if needed and runs migrations for relational providers (SQL Server, SQLite, PostgreSQL) so schema changes are applied automatically. Each entity is placed under a `Features/<Entity>` folder in every layer and follows a CQRS-aware vertical slice:
 
 ```
 Application/<Entity>/
@@ -94,7 +94,7 @@ Extend an existing slice or create a minimal slice with a single action:
 dotnet-arch new action --entity=EntityName --action=download --output=../MyApp
 ```
 
-When running outside the solution directory, pass `--output` so the tool can locate `dotnet-arch.yml`. By default the action is treated as a command. To scaffold a query instead, append `--is-command=false`:
+When running outside the solution directory the command reuses the last saved solution path. Provide `--output` to override it and point to a different `dotnet-arch.yml`. By default the action is treated as a command. To scaffold a query instead, append `--is-command=false`:
 
 ```
 dotnet-arch new action --entity=EntityName --action=getfile --is-command=false --output=../MyApp
@@ -104,13 +104,13 @@ The tool generates the command or query, handler, validator, repository method, 
 
 #### Run the Startup Project
 
-After scaffolding, launch the API with automatic EF Core migrations:
+After scaffolding, launch the API and optionally apply EF Core migrations:
 
 ```
 dotnet-arch exec [--output=Path]
 ```
 
-This checks for model changes, creates a new migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
+When run, the command asks whether to check for model changes. Choosing **y** creates a migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
 
 ---
 
@@ -183,10 +183,10 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
-- **`exec` command**: Run the startup project while automatically generating and applying pending EF Core migrations.
+- **`exec` command**: Run the startup project with an optional migration check that can generate and apply pending EF Core migrations.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.
-- **Custom output path**: Both `new solution` and `new crud` accept an `--output` option so code can be generated in test directories or alternative locations.
+- **Custom output path**: Commands remember the last solution path but accept an `--output` option so code can be generated in test directories or alternative locations.
 - **Development Swagger setup**: API projects automatically reference `Microsoft.AspNetCore.OpenApi` and `Swashbuckle.AspNetCore`, register Swagger services, and enable Swagger UI in development while removing default template files and sample endpoints.
 - **Feature-based folder structure**: Each layer organizes code under `Features/<Entity>` so all slices stay grouped.
   - **Automatic migrations**: `new crud`, `new action`, and `exec` verify `dotnet-ef` and attempt installation if needed. For relational providers (SQL Server, SQLite, PostgreSQL) migrations and database updates run automatically; for MongoDB the process skips migrations. Generated `Program.cs` calls `Database.Migrate()` on startup to apply any pending migrations so new tables are created automatically.


### PR DESCRIPTION
## Summary
- default the startup project to API without prompting
- track the last generated solution path for CRUD/action commands
- document that alternative database providers are still experimental

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b56a074dd08323acd4a4687ca7180a