### PR TITLE
Add HttpRequest service scaffolding

### DIFF
--- a/ServiceScaffolder.cs
+++ b/ServiceScaffolder.cs
@@ -15,14 +15,21 @@ static class ServiceScaffolder
         var type = Program.AskOption("Select service type", new[] { "Custom", "Cache", "Message Broker", "HttpRequest" });
         var solution = config.SolutionName;
 
-        if (type == "Custom")
-            HandleCustom(config, solution);
-        else if (type == "Cache")
-            HandleCache(config, solution);
-        else if (type == "Message Broker")
-            HandleMessageBroker(config, solution);
-        else
-            HandleHttpRequest(config, solution);
+        switch (type)
+        {
+            case "Custom":
+                HandleCustom(config, solution);
+                break;
+            case "Cache":
+                HandleCache(config, solution);
+                break;
+            case "Message Broker":
+                HandleMessageBroker(config, solution);
+                break;
+            case "HttpRequest":
+                HandleHttpRequest(config, solution);
+                break;
+        }
     }
 
     static void HandleCustom(SolutionConfig config, string solution)

--- a/ServiceScaffolder.cs
+++ b/ServiceScaffolder.cs
@@ -187,6 +187,8 @@ static class ServiceScaffolder
         var classNs = $"{solution}.Infrastructure.Services.HttpRequest";
         WriteHttpRequestClass(infraDir, classNs, cls, iface, ifaceNs);
 
+        InstallPackage(config, "Microsoft.Extensions.Http", "8.0.0");
+
         AddServiceToDi(config, "Infrastructure", iface, ifaceNs, cls, classNs, "AddHttpClient");
         EnsureProgramCalls(config, "Infrastructure");
         Program.Success("HttpRequest service generated.");


### PR DESCRIPTION
## Summary
- add HttpRequest option to service scaffolder
- generate IHttpRequestService and HttpRequestService with REST methods
- register HttpRequestService via AddHttpClient in Infrastructure DI

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b81c0b08c8832cad2c67aff1f19a4f