### PR TITLE
Add Docker execution support

### DIFF
--- a/DockerState.cs
+++ b/DockerState.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+public class DockerStateData
+{
+    public string? LastContainer { get; set; }
+    public string? LastImage { get; set; }
+}
+
+public static class DockerState
+{
+    private const string FileName = ".dotnet-arch-docker";
+
+    public static void Save(DockerStateData data)
+    {
+        var file = GetFile();
+        var json = JsonSerializer.Serialize(data);
+        File.WriteAllText(file, json);
+    }
+
+    public static DockerStateData Load()
+    {
+        var file = GetFile();
+        if (!File.Exists(file))
+            return new DockerStateData();
+        var json = File.ReadAllText(file);
+        return JsonSerializer.Deserialize<DockerStateData>(json) ?? new DockerStateData();
+    }
+
+    private static string GetFile()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, FileName);
+    }
+}

--- a/Main.cs
+++ b/Main.cs
@@ -765,7 +765,7 @@ class Program
             if (RunCommand("choco --version", print: false))
                 cmd = "choco install git -y";
             else if (RunCommand("winget --version", print: false))
-                cmd = "winget install -e --id Git.Git";
+                cmd = "winget install -e --id Git.Git --accept-package-agreements --accept-source-agreements --silent";
             else
             {
                 Error("No package manager found to install Git. Please install Git manually.");
@@ -794,7 +794,7 @@ class Program
             if (RunCommand("choco --version", print: false))
                 cmd = "choco install docker-desktop -y";
             else if (RunCommand("winget --version", print: false))
-                cmd = "winget install -e --id Docker.DockerDesktop";
+                cmd = "winget install -e --id Docker.DockerDesktop --accept-package-agreements --accept-source-agreements --silent";
             else
             {
                 Error("No package manager found to install Docker. Please install Docker Desktop manually.");
@@ -823,7 +823,7 @@ class Program
             if (RunCommand("choco --version", print: false))
                 cmd = "choco install docker-compose -y";
             else if (RunCommand("winget --version", print: false))
-                cmd = "winget install -e --id Docker.DockerCompose";
+                cmd = "winget install -e --id Docker.DockerCompose --accept-package-agreements --accept-source-agreements --silent";
             else
             {
                 Error("No package manager found to install Docker Compose. Install it manually from https://docs.docker.com/compose/install/.");

--- a/Main.cs
+++ b/Main.cs
@@ -674,7 +674,17 @@ class Program
 
         string cmd;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            cmd = "choco install docker-desktop";
+        {
+            if (RunCommand("choco --version", print: false))
+                cmd = "choco install docker-desktop -y";
+            else if (RunCommand("winget --version", print: false))
+                cmd = "winget install -e --id Docker.DockerDesktop";
+            else
+            {
+                Error("No package manager found to install Docker. Please install Docker Desktop manually.");
+                return false;
+            }
+        }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             cmd = "brew install --cask docker";
         else
@@ -693,7 +703,17 @@ class Program
 
         string cmd;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            cmd = "choco install docker-compose";
+        {
+            if (RunCommand("choco --version", print: false))
+                cmd = "choco install docker-compose -y";
+            else if (RunCommand("winget --version", print: false))
+                cmd = "winget install -e --id Docker.DockerCompose";
+            else
+            {
+                Error("No package manager found to install Docker Compose. Install it manually from https://docs.docker.com/compose/install/.");
+                return false;
+            }
+        }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             cmd = "brew install docker-compose";
         else

--- a/README.MD
+++ b/README.MD
@@ -210,7 +210,7 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
 - **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required. Add `--docker` to build and run via Docker Compose.
-- **Resilient Docker setup**: Automatically attempts to start the Docker daemon, skips redundant Compose installs on Windows, and offers a safe reinstall that preserves existing images and containers.
+- **Resilient Docker setup**: Automatically launches the Docker daemon after install, avoids redundant Docker Compose prompts when Docker Desktop already bundles it, and offers a safe reinstall that preserves existing images and containers.
 - **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.

--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ Once installed, you can use the tool to create a solution structure:
 dotnet-arch new solution <SolutionName> [--output=Path] [--startup=ProjectName] [--style=controller|fast]
 ```
 
-`--output` is optional and lets you specify where the solution is created (useful for tests). If omitted, the current directory is used. `--startup` lets you choose which project should act as the startup project (default is `<SolutionName>.API`). `--style` selects between classic **Controller** APIs or lightweight **Fast** minimal APIs (default `controller`). Missing parameters are prompted interactively with defaults shown in brackets; when selecting API style, simply enter **1** for Controller or **2** for Fast. During creation you'll be prompted for a database provider (SQL Server or SQLite; hitting enter selects SQLite). After scaffolding, a `dotnet-arch.yml` file records the solution name, path, startup project, API style, chosen provider, and the scaffolding state of each entity so later commands can skip work already done. Swagger and service registrations are configured at this stage so the API runs immediately.
+`--output` is optional and lets you specify where the solution is created (useful for tests). If omitted, the current directory is used. `--startup` lets you choose which project should act as the startup project (default is `<SolutionName>.API`). `--style` selects between classic **Controller** APIs or lightweight **Fast** minimal APIs (default `controller`). Missing parameters are prompted interactively with defaults shown in brackets; when selecting API style, simply enter **1** for Controller or **2** for Fast. During creation you'll be prompted for a database provider (SQL Server or SQLite; hitting enter selects SQLite). After scaffolding, a `dotnet-arch.yml` file records the solution name, path, startup project, API style, chosen provider, and the scaffolding state of each entity so later commands can skip work already done. Swagger and service registrations are configured at this stage so the API runs immediately. You'll also be asked whether to initialize a Git repository; if confirmed the tool ensures Git is installed, runs `git init`, and adds a .NET `.gitignore`.
 
 This command generates the following layers:
 
@@ -125,6 +125,7 @@ dotnet-arch exec [--output=Path] [--docker]
 ```
 
 When run, the command asks whether to check for model changes. Choosing **y** creates a migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
+Adding `--docker` builds and runs the API with Docker Compose, exposing the port defined in the API project's launch settings and tagging the image with the project version.
 
 #### Manage Migrations
 

--- a/README.MD
+++ b/README.MD
@@ -200,6 +200,7 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Cross-Platform**: Fully functional on Windows, macOS, and Linux.
 - **Domain-Driven Design Support**: Includes pre-configured layers for DDD.
 - **Ease of Use**: Intuitive and straightforward CLI commands.
+- **Command progress display**: Long-running operations render an animated spinner.
 - **`new crud` scaffolding**: Generates vertical-slice CQRS CRUD with MediatR, FluentValidation, EF Core repositories, and paginated results.
 - **Database Provider Selection**: Choose between SQL Server, SQLite, PostgreSQL or MongoDB (default SQLite); the selected provider is stored so future runs don't prompt again.
   - *Other providers are experimental and require more testing and development before a NuGet release.*

--- a/README.MD
+++ b/README.MD
@@ -210,7 +210,7 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
 - **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required. Add `--docker` to build and run via Docker Compose.
-- **Resilient Docker setup**: Detects incomplete Docker installations and offers a safe reinstall that preserves existing images and containers.
+- **Resilient Docker setup**: Automatically attempts to start the Docker daemon, skips redundant Compose installs on Windows, and offers a safe reinstall that preserves existing images and containers.
 - **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.

--- a/README.MD
+++ b/README.MD
@@ -121,7 +121,7 @@ Selecting **Cache** or **Message Broker** scaffolds ready‑to‑use Redis or Ra
 After scaffolding, launch the API and optionally apply EF Core migrations:
 
 ```
-dotnet-arch exec [--output=Path]
+dotnet-arch exec [--output=Path] [--docker]
 ```
 
 When run, the command asks whether to check for model changes. Choosing **y** creates a migration if needed, applies pending migrations, and then runs the configured startup project. The optional `--output` overrides the last solution path stored by the tool.
@@ -207,7 +207,7 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
-- **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required.
+ - **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required. Add `--docker` to build and run via Docker Compose.
 - **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.

--- a/README.MD
+++ b/README.MD
@@ -209,7 +209,8 @@ We welcome contributions to DotNetArch! Here’s how you can contribute:
 - **Automatic package & service registration**: Required NuGet packages are added to project files and services like `DbContext`, `IMediator`, `IUnitOfWork`, and validators are registered in `Program.cs`.
 - **`new action` command**: Add custom commands or queries with handlers, validators, repository methods, and controller endpoints.
 - **Composable actions and slices**: Actions scaffolded before a full `new crud` run are preserved and the later CRUD generation augments the existing files instead of overwriting them.
- - **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required. Add `--docker` to build and run via Docker Compose.
+- **`exec` command**: Run the startup project with an optional migration check that generates missing migrations, applies any pending ones, and otherwise launches the project directly if no updates are required. Add `--docker` to build and run via Docker Compose.
+- **Resilient Docker setup**: Detects incomplete Docker installations and offers a safe reinstall that preserves existing images and containers.
 - **`remove migration` command**: Roll the database back and delete the most recent EF Core migration.
 - **Correct namespace wiring**: `Program.cs` updates include the necessary `using` directives and service registrations for each entity's repository without malformed entries.
 - **Configurable startup project**: `dotnet-arch.yml` tracks which project is the startup target so controllers are added to the correct application entry point.


### PR DESCRIPTION
## Summary
- generate Dockerfile, docker-compose, and environment file when creating a solution
- add `--docker` option to `exec` to run via Docker Compose and clean up containers and images
- document Docker execution usage

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0` (fails to build net9.0)
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b82ed46b84832c8a212e09ee911f63