### PR TITLE
feat: add git initialization step

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -145,9 +145,9 @@ class Program
             }
 
             var solutionPath = config.SolutionPath;
-            EnsureDotnetGitIgnore(solutionPath);
             if (AskYesNo("Initialize git repository?", true))
             {
+                EnsureDotnetGitIgnore(solutionPath);
                 if (IsGitInstalled())
                     RunCommand("git init", solutionPath);
                 else
@@ -349,11 +349,11 @@ class Program
 
         Directory.SetCurrentDirectory(solutionDir);
 
-        EnsureDotnetGitIgnore(solutionDir);
         var gitInstalled = IsGitInstalled();
         var gitInitialized = false;
         if (AskYesNo("Initialize git repository?", true))
         {
+            EnsureDotnetGitIgnore(solutionDir);
             if (gitInstalled)
             {
                 gitInitialized = RunCommand("git init", solutionDir);


### PR DESCRIPTION
## Summary
- prompt to optionally initialize git when running `exec`
- ensure a default .NET `.gitignore` file exists

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b925be2fb0832c91efd75f4b943126