### PR TITLE
Add event scaffolding command

### DIFF
--- a/EventScaffolder.cs
+++ b/EventScaffolder.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DotNetArch.Scaffolding;
+
+static class EventScaffolder
+{
+    public static string[] ListEvents(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+        var eventsDir = Path.Combine(config.SolutionPath, $"{solution}.Application", "Features", plural, "Events");
+        if (!Directory.Exists(eventsDir))
+            return Array.Empty<string>();
+        return Directory.GetFiles(eventsDir, $"{entity}*Event.cs")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => n.StartsWith(entity) && n.EndsWith("Event"))
+            .Select(n => n.Substring(entity.Length, n.Length - entity.Length - "Event".Length))
+            .ToArray();
+    }
+
+    public static bool GenerateEvent(SolutionConfig config, string entity, string eventName)
+    {
+        if (string.IsNullOrWhiteSpace(config.SolutionName) || string.IsNullOrWhiteSpace(entity) || string.IsNullOrWhiteSpace(eventName))
+        {
+            Program.Error("Solution, entity and event names are required.");
+            return false;
+        }
+        eventName = Upper(eventName);
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+        var appDir = Path.Combine(config.SolutionPath, $"{solution}.Application");
+        var featureDir = Path.Combine(appDir, "Features", plural);
+        if (!Directory.Exists(featureDir))
+            return false;
+        var eventsDir = Path.Combine(featureDir, "Events");
+        Directory.CreateDirectory(eventsDir);
+        var eventClass = $"{entity}{eventName}Event";
+        var file = Path.Combine(eventsDir, eventClass + ".cs");
+        if (!File.Exists(file))
+        {
+            var content = $@"using MediatR;
+using {solution}.Core.Features.{plural}.Entities;
+
+namespace {solution}.Application.Features.{plural}.Events;
+
+public class {eventClass} : INotification
+{{
+    public {entity} {entity} {{ get; }}
+    public {eventClass}({entity} {LowerFirst(entity)}) => {entity} = {LowerFirst(entity)};
+}}";
+            File.WriteAllText(file, content);
+        }
+        return true;
+    }
+
+    public static bool AddSubscriber(SolutionConfig config, string eventEntity, string eventName, string subscriberEntity)
+    {
+        var solution = config.SolutionName;
+        var subscriberPlural = Naming.Pluralize(subscriberEntity);
+        var subFeatureDir = Path.Combine(config.SolutionPath, $"{solution}.Application", "Features", subscriberPlural);
+        if (!Directory.Exists(subFeatureDir))
+            return false;
+        var handlersDir = Path.Combine(subFeatureDir, "EventHandlers");
+        Directory.CreateDirectory(handlersDir);
+        eventName = Upper(eventName);
+        var handlerClass = $"{eventEntity}{eventName}EventHandler";
+        var file = Path.Combine(handlersDir, handlerClass + ".cs");
+        var eventPlural = Naming.Pluralize(eventEntity);
+        var content = $@"using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using {solution}.Application.Features.{eventPlural}.Events;
+
+namespace {solution}.Application.Features.{subscriberPlural}.EventHandlers;
+
+public class {handlerClass} : INotificationHandler<{eventEntity}{eventName}Event>
+{{
+    public Task Handle({eventEntity}{eventName}Event notification, CancellationToken cancellationToken)
+    {{
+        // TODO: Add handling logic
+        return Task.CompletedTask;
+    }}
+}}";
+        File.WriteAllText(file, content);
+        return true;
+    }
+
+    static string LowerFirst(string text) => string.IsNullOrEmpty(text) ? text : char.ToLower(text[0]) + text.Substring(1);
+    static string Upper(string text) => string.IsNullOrEmpty(text) ? text : char.ToUpper(text[0]) + text.Substring(1);
+}

--- a/EventScaffolder.cs
+++ b/EventScaffolder.cs
@@ -7,6 +7,14 @@ using DotNetArch.Scaffolding;
 
 static class EventScaffolder
 {
+    public static bool EntityExists(SolutionConfig config, string entity)
+    {
+        var solution = config.SolutionName;
+        var plural = Naming.Pluralize(entity);
+        var featureDir = Path.Combine(config.SolutionPath, $"{solution}.Application", "Features", plural);
+        return Directory.Exists(featureDir);
+    }
+
     public static string[] ListEvents(SolutionConfig config, string entity)
     {
         var solution = config.SolutionName;

--- a/Main.cs
+++ b/Main.cs
@@ -98,6 +98,14 @@ class Program
                 }
                 entity = SanitizeIdentifier(entity);
 
+                if (!EventScaffolder.EntityExists(config, entity))
+                {
+                    Error($"Entity '{entity}' does not exist.");
+                    entity = null;
+                    eventName = null;
+                    continue;
+                }
+
                 var events = EventScaffolder.ListEvents(config, entity);
                 if (events.Length == 0 && string.IsNullOrWhiteSpace(eventName))
                     eventName = Ask("Enter event name");
@@ -146,12 +154,11 @@ class Program
                 var currentEvent = eventName;
                 while (true)
                 {
-                    string choice;
-                    if (events.Length > 1)
-                        choice = Ask("1) Add subscriber  2) Add subscriber for other events  3) Finish");
-                    else
-                        choice = Ask("1) Add subscriber  2) Finish");
-                    if (choice == "1")
+                    var options = events.Length > 1
+                        ? new[] { "Add subscriber", "Add subscriber for other events", "Finish" }
+                        : new[] { "Add subscriber", "Finish" };
+                    var choice = AskOption("Select action", options);
+                    if (choice == "Add subscriber")
                     {
                         var sub = Ask("Enter subscriber entity");
                         sub = SanitizeIdentifier(sub);
@@ -162,12 +169,14 @@ class Program
                         }
                         Success($"Subscriber {sub} added.");
                     }
-                    else if (choice == "2" && events.Length > 1)
+                    else if (choice == "Add subscriber for other events")
                     {
                         currentEvent = AskOption("Select event", events);
                     }
                     else
+                    {
                         break;
+                    }
                 }
                 break;
             }

--- a/Main.cs
+++ b/Main.cs
@@ -112,7 +112,11 @@ class Program
 
                 if (string.IsNullOrWhiteSpace(eventName))
                 {
-                    var action = AskOption($"Entity '{entity}' has existing events. Select action", new[] { "Create new event", "Add subscriber to existing events" });
+                    var actionOptions = new[] { "Create new event", "Add subscriber to existing events", "Cancel" };
+                    var action = AskOption($"Entity '{entity}' has existing events. Select action", actionOptions);
+                    if (action == "Cancel")
+                        return;
+
                     if (action == "Create new event")
                     {
                         eventName = Ask("Enter event name");
@@ -134,7 +138,16 @@ class Program
                     }
                     else
                     {
-                        eventName = AskOption("Select event", events);
+                        var eventOptions = events.Concat(new[] { "Back", "Cancel" }).ToArray();
+                        var selected = AskOption("Select event", eventOptions);
+                        if (selected == "Back")
+                        {
+                            eventName = null;
+                            continue;
+                        }
+                        if (selected == "Cancel")
+                            return;
+                        eventName = selected;
                     }
                 }
                 else
@@ -155,8 +168,8 @@ class Program
                 while (true)
                 {
                     var options = events.Length > 1
-                        ? new[] { "Add subscriber", "Add subscriber for other events", "Finish" }
-                        : new[] { "Add subscriber", "Finish" };
+                        ? new[] { "Add subscriber", "Add subscriber for other events", "Finish", "Cancel" }
+                        : new[] { "Add subscriber", "Finish", "Cancel" };
                     var choice = AskOption("Select action", options);
                     if (choice == "Add subscriber")
                     {
@@ -171,7 +184,17 @@ class Program
                     }
                     else if (choice == "Add subscriber for other events")
                     {
-                        currentEvent = AskOption("Select event", events);
+                        var eventOptions = events.Concat(new[] { "Back", "Cancel" }).ToArray();
+                        var selected = AskOption("Select event", eventOptions);
+                        if (selected == "Back")
+                            continue;
+                        if (selected == "Cancel")
+                            return;
+                        currentEvent = selected;
+                    }
+                    else if (choice == "Cancel")
+                    {
+                        return;
                     }
                     else
                     {

--- a/Main.cs
+++ b/Main.cs
@@ -168,8 +168,8 @@ class Program
                 while (true)
                 {
                     var options = events.Length > 1
-                        ? new[] { "Add subscriber", "Add subscriber for other events", "Finish", "Cancel" }
-                        : new[] { "Add subscriber", "Finish", "Cancel" };
+                        ? new[] { "Add subscriber", "Add subscriber for other events", "Finish" }
+                        : new[] { "Add subscriber", "Finish" };
                     var choice = AskOption("Select action", options);
                     if (choice == "Add subscriber")
                     {
@@ -191,10 +191,6 @@ class Program
                         if (selected == "Cancel")
                             return;
                         currentEvent = selected;
-                    }
-                    else if (choice == "Cancel")
-                    {
-                        return;
                     }
                     else
                     {

--- a/Main.cs
+++ b/Main.cs
@@ -128,8 +128,6 @@ class Program
                         eventName = SanitizeIdentifier(eventName);
                         if (!EventScaffolder.GenerateEvent(config, entity, eventName))
                         {
-                            Error($"Entity '{entity}' does not exist.");
-                            entity = null;
                             eventName = null;
                             continue;
                         }
@@ -155,8 +153,6 @@ class Program
                     eventName = SanitizeIdentifier(eventName);
                     if (!EventScaffolder.GenerateEvent(config, entity, eventName))
                     {
-                        Error($"Entity '{entity}' does not exist.");
-                        entity = null;
                         eventName = null;
                         continue;
                     }
@@ -176,10 +172,8 @@ class Program
                         var sub = Ask("Enter subscriber entity");
                         sub = SanitizeIdentifier(sub);
                         if (!EventScaffolder.AddSubscriber(config, entity, currentEvent!, sub))
-                        {
-                            Error("Subscriber entity not found.");
                             continue;
-                        }
+        
                         Success($"Subscriber {sub} added.");
                     }
                     else if (choice == "Add subscriber for other events")


### PR DESCRIPTION
## Summary
- add `ListEvents` helper to enumerate existing events for an entity
- extend `new event` flow to choose between creating a new event or subscribing to existing ones
- support switching between events when adding multiple subscribers

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68ba22100484832c997c4c19bc68ab5a