### PR TITLE
feat: add detached docker execution option

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,7 +56,8 @@ This layout exposes all the moving parts up front—application layers, environm
 ## Features
 - **One-command solution scaffolding** with Core, Application, Infrastructure, and API layers—choose **controller** or **fast** minimal APIs.
 - **Git & docs bootstrap**: initializes a repository, adds a `.gitignore`, and drops in a README template.
-- **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit. Use `exec --docker-detach` to keep the container running in the background with the same helpful logging, and `exec --docker-stop` to tear it down later.
+- **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit.
+- **Detached Docker lifecycle**: `exec --docker-detach` runs containers in the background with step-by-step logging, and `exec --docker-stop` safely stops and removes them when you're done.
 - **Environment-specific configuration**: prepopulated `.env` and `appsettings` files for development, test, and production under `API/Config`.
 - **Vertical-slice CRUD generation** using MediatR, FluentValidation, and Unit-of-Work based EF Core repositories with pagination helpers.
 - **Unit-of-Work repositories** are created automatically so your data layer is production-ready from the start.
@@ -115,10 +116,10 @@ dotnet-arch exec --docker
 # builds an image, starts a container, auto-applies migrations, and cleans it up on exit
 
 dotnet-arch exec --docker-detach
-# builds an image, starts a container in the background, and leaves it running
+# builds an image, starts a container in the background, logs setup steps, and leaves it running
 
 dotnet-arch exec --docker-stop
-# stops and removes the detached container and image
+# safely stops and removes the detached container and image
 ```
 Missing options are prompted with sane defaults, keeping the experience smooth for newcomers.
 
@@ -169,7 +170,7 @@ Interfaces and implementations are placed in the appropriate layer and registere
 ```bash
 dotnet-arch exec [--output=Path] [--docker] [--docker-detach] [--docker-stop]
 ```
-Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit. With `--docker-detach`, performs the same setup but leaves the container running in the background without streaming logs or cleaning up. With `--docker-stop`, safely stops and removes the container and image from a detached run.
+Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit. With `--docker-detach`, performs the same setup with step-by-step logging but leaves the container running in the background without streaming logs or cleaning up. With `--docker-stop`, safely stops and removes the container and image from a detached run.
 
 ### remove migration
 ```bash

--- a/README.MD
+++ b/README.MD
@@ -56,7 +56,7 @@ This layout exposes all the moving parts up front—application layers, environm
 ## Features
 - **One-command solution scaffolding** with Core, Application, Infrastructure, and API layers—choose **controller** or **fast** minimal APIs.
 - **Git & docs bootstrap**: initializes a repository, adds a `.gitignore`, and drops in a README template.
-- **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit.
+ - **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit. Use `exec --docker-detach` to keep the container running in the background with the same helpful logging.
 - **Environment-specific configuration**: prepopulated `.env` and `appsettings` files for development, test, and production under `API/Config`.
 - **Vertical-slice CRUD generation** using MediatR, FluentValidation, and Unit-of-Work based EF Core repositories with pagination helpers.
 - **Unit-of-Work repositories** are created automatically so your data layer is production-ready from the start.
@@ -113,6 +113,9 @@ dotnet-arch new service
 
 dotnet-arch exec --docker
 # builds an image, starts a container, auto-applies migrations, and cleans it up on exit
+
+dotnet-arch exec --docker-detach
+# builds an image, starts a container in the background, and leaves it running
 ```
 Missing options are prompted with sane defaults, keeping the experience smooth for newcomers.
 
@@ -161,9 +164,9 @@ Interfaces and implementations are placed in the appropriate layer and registere
 
 ### exec
 ```bash
-dotnet-arch exec [--output=Path] [--docker]
+dotnet-arch exec [--output=Path] [--docker] [--docker-detach]
 ```
-Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit.
+Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit. With `--docker-detach`, performs the same setup but leaves the container running in the background without streaming logs or cleaning up.
 
 ### remove migration
 ```bash

--- a/README.MD
+++ b/README.MD
@@ -56,7 +56,7 @@ This layout exposes all the moving parts up front—application layers, environm
 ## Features
 - **One-command solution scaffolding** with Core, Application, Infrastructure, and API layers—choose **controller** or **fast** minimal APIs.
 - **Git & docs bootstrap**: initializes a repository, adds a `.gitignore`, and drops in a README template.
- - **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit. Use `exec --docker-detach` to keep the container running in the background with the same helpful logging.
+- **Docker-friendly**: generates Dockerfile and `docker-compose.yml`; `exec --docker` builds images, starts containers, streams logs, and cleans everything up safely on exit. Use `exec --docker-detach` to keep the container running in the background with the same helpful logging, and `exec --docker-stop` to tear it down later.
 - **Environment-specific configuration**: prepopulated `.env` and `appsettings` files for development, test, and production under `API/Config`.
 - **Vertical-slice CRUD generation** using MediatR, FluentValidation, and Unit-of-Work based EF Core repositories with pagination helpers.
 - **Unit-of-Work repositories** are created automatically so your data layer is production-ready from the start.
@@ -116,6 +116,9 @@ dotnet-arch exec --docker
 
 dotnet-arch exec --docker-detach
 # builds an image, starts a container in the background, and leaves it running
+
+dotnet-arch exec --docker-stop
+# stops and removes the detached container and image
 ```
 Missing options are prompted with sane defaults, keeping the experience smooth for newcomers.
 
@@ -164,9 +167,9 @@ Interfaces and implementations are placed in the appropriate layer and registere
 
 ### exec
 ```bash
-dotnet-arch exec [--output=Path] [--docker] [--docker-detach]
+dotnet-arch exec [--output=Path] [--docker] [--docker-detach] [--docker-stop]
 ```
-Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit. With `--docker-detach`, performs the same setup but leaves the container running in the background without streaming logs or cleaning up.
+Launches the startup project. Detects entity property changes, creates and applies migrations automatically, and then runs the API. With `--docker`, builds the image, starts the container, streams logs, and tears everything down safely on exit. With `--docker-detach`, performs the same setup but leaves the container running in the background without streaming logs or cleaning up. With `--docker-stop`, safely stops and removes the container and image from a detached run.
 
 ### remove migration
 ```bash


### PR DESCRIPTION
## Summary
- support `exec --docker-detach` to run containers without streaming logs
- document detached docker execution in README

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_b_68ba9e09a5b8832c8e9281ad2e8fd3d1