### PR TITLE
Allow specifying HTTP method for new action scaffolds

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -317,8 +317,8 @@ class Program
         {
             string? entity = null;
             string? action = null;
+            string? method = null;
             string? outputPath = null;
-            bool? isCommand = null;
 
             for (int i = 2; i < args.Length; i++)
             {
@@ -326,8 +326,8 @@ class Program
                     entity = args[i].Substring("--entity=".Length);
                 else if (args[i].StartsWith("--action="))
                     action = args[i].Substring("--action=".Length);
-                else if (args[i].StartsWith("--is-command="))
-                    isCommand = bool.Parse(args[i].Substring("--is-command=".Length));
+                else if (args[i].StartsWith("--method="))
+                    method = args[i].Substring("--method=".Length);
                 else if (args[i].StartsWith("--output="))
                     outputPath = args[i].Substring("--output=".Length);
             }
@@ -336,17 +336,26 @@ class Program
                 entity = Ask("Enter entity name");
             if (string.IsNullOrWhiteSpace(action))
                 action = Ask("Enter action name");
-            if (string.IsNullOrWhiteSpace(entity) || string.IsNullOrWhiteSpace(action))
+            if (string.IsNullOrWhiteSpace(method))
+                method = Ask("Enter HTTP method");
+            if (string.IsNullOrWhiteSpace(entity) || string.IsNullOrWhiteSpace(action) || string.IsNullOrWhiteSpace(method))
             {
-                Error("Entity and action are required.");
+                Error("Entity, action and method are required.");
                 return;
             }
 
             entity = SanitizeIdentifier(entity);
             action = SanitizeIdentifier(action);
 
-            if (isCommand == null)
-                isCommand = AskYesNo("Is command?", true);
+            var allowedMethods = new[] { "GET", "POST", "PUT", "DELETE" };
+            if (!allowedMethods.Contains(method, StringComparer.OrdinalIgnoreCase))
+            {
+                Error($"Invalid HTTP method. Allowed methods: {string.Join(", ", allowedMethods)}.");
+                return;
+            }
+
+            bool isCommand = !method.Equals("GET", StringComparison.OrdinalIgnoreCase);
+
             if (string.IsNullOrWhiteSpace(outputPath))
                 outputPath = PathState.Load() ?? Directory.GetCurrentDirectory();
 
@@ -358,7 +367,7 @@ class Program
                 return;
             }
 
-            ActionScaffolder.Generate(config, entity, action, isCommand.Value);
+            ActionScaffolder.Generate(config, entity, action, isCommand, method.ToUpperInvariant());
             return;
         }
 


### PR DESCRIPTION
## Summary
- accept `--method` when creating a new action and validate against common HTTP verbs
- generate endpoint/controller methods using the chosen HTTP verb

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68bac985bacc832c85101df5ec044d1d