### PR TITLE
fix: align package versions with target tfm

### DIFF
--- a/DotNetArch.csproj
+++ b/DotNetArch.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool> <!-- Convert To Global Tool -->
     <ToolCommandName>dotnet-arch</ToolCommandName> <!-- For Execute CLI -->
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <Authors>Moein Rezaee</Authors>
     <Description>A CLI tool for creating Clean Architecture solutions.</Description>
@@ -15,6 +14,16 @@
     <RepositoryUrl>https://github.com/moein-rezaee/DotNetArch.git</RepositoryUrl>
     <PackageIcon>assets/icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <!-- Debug: اجرای ساده با یک فریم‌ورک پیش‌فرض -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Release: چندفریم‌ورکی برای پکیج ابزار -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DotNetArch.csproj
+++ b/DotNetArch.csproj
@@ -9,7 +9,7 @@
     <Description>A CLI tool for creating Clean Architecture solutions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DotNetArch</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <PackageTags>dotnet;cli;clean-architecture;scaffold;dotnetarch</PackageTags> 
     <RepositoryUrl>https://github.com/moein-rezaee/DotNetArch.git</RepositoryUrl>
     <PackageIcon>assets/icon.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This layout exposes all the moving parts up front—application layers, environm
 - **Cross-platform** and tested on Windows, macOS, and Linux.
 
 ## Requirements
-- [.NET SDK](https://dotnet.microsoft.com/download) **6.0+** (recommended: 8.0)
+- [.NET SDK](https://dotnet.microsoft.com/download) **8.0+** (the CLI targets `net8.0` and `net9.0` automatically)
 - Supported OS: Windows 10+, macOS Catalina+, or any modern Linux distribution
 - [Git](https://git-scm.com/) for cloning or contributing
 
@@ -134,6 +134,16 @@ dotnet-arch exec --docker-stop
 # safely stops and removes the detached container and image
 ```
 Missing options are prompted with sane defaults, keeping the experience smooth for newcomers.
+
+## Working with Multiple .NET SDKs
+DotNetArch is multi-targeted so you can keep several SDKs installed without friction.
+
+- The tool ships for both `net8.0` and `net9.0`. When running it from the repository, use the helper scripts to pick the best match automatically:
+  - macOS/Linux: `./scripts/run.sh -- --help`
+  - Windows (PowerShell): `pwsh ./scripts/run.ps1 -- --help`
+  - Prefer manual control? Run `dotnet run -f net8.0 -- --help` (or `net9.0`) instead.
+- Newly generated solutions include a `global.json` with `rollForward` set to `latestMajor`, so your projects transparently adopt the highest installed .NET 8/9 SDK.
+- During scaffolding DotNetArch inspects `dotnet --list-sdks` and selects the highest supported target framework, ensuring the produced projects match your environment.
 
 ## Command Reference
 ### new solution

--- a/Scaffolding/PackageVersionResolver.cs
+++ b/Scaffolding/PackageVersionResolver.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace DotNetArch.Scaffolding;
+
+public static class PackageVersionResolver
+{
+    public static string ResolveSharedFrameworkPackageVersion(string? targetFramework)
+    {
+        var major = ResolveTargetMajor(targetFramework);
+        return $"{major}.0.0";
+    }
+
+    public static int ResolveTargetMajor(string? targetFramework)
+    {
+        if (string.IsNullOrWhiteSpace(targetFramework))
+            return 8;
+
+        var match = Regex.Match(targetFramework, @"net(\d+)");
+        if (match.Success && int.TryParse(match.Groups[1].Value, out var parsed))
+        {
+            if (parsed < 8)
+                return 8;
+            if (parsed > 9)
+                return 9;
+            return parsed;
+        }
+
+        return 8;
+    }
+}

--- a/Scaffolding/Steps/ProjectUpdateStep.cs
+++ b/Scaffolding/Steps/ProjectUpdateStep.cs
@@ -17,6 +17,7 @@ public class ProjectUpdateStep : IScaffoldStep
     // Will be computed per target framework
     private static string _efCoreVersion = "8.0.0";
     private static string _openApiVersion = "8.0.0";
+    private static string _extensionsVersion = "8.0.0";
 
     public void Execute(SolutionConfig config, string entity)
     {
@@ -28,11 +29,10 @@ public class ProjectUpdateStep : IScaffoldStep
         var infraPath = Path.Combine(basePath, $"{solution}.Infrastructure");
         // Choose package versions based on selected TFM
         var tfm = config.TargetFramework ?? "net8.0";
-        if (tfm.StartsWith("net9."))
-        {
-            _efCoreVersion = "9.0.0";
-            _openApiVersion = "9.0.0";
-        }
+        var sharedFxVersion = PackageVersionResolver.ResolveSharedFrameworkPackageVersion(tfm);
+        _efCoreVersion = sharedFxVersion;
+        _openApiVersion = sharedFxVersion;
+        _extensionsVersion = sharedFxVersion;
         var persistencePath = Path.Combine(infraPath, "Persistence");
         if (provider == "SQLite")
         {
@@ -145,8 +145,8 @@ public class ProjectUpdateStep : IScaffoldStep
 
         var doc = XDocument.Load(infraProj);
         // Always ensure DI/config abstractions for library-level IServiceCollection/IConfiguration
-        EnsurePackage(doc, "Microsoft.Extensions.DependencyInjection.Abstractions", "8.0.0");
-        EnsurePackage(doc, "Microsoft.Extensions.Configuration.Abstractions", "8.0.0");
+        EnsurePackage(doc, "Microsoft.Extensions.DependencyInjection.Abstractions", _extensionsVersion);
+        EnsurePackage(doc, "Microsoft.Extensions.Configuration.Abstractions", _extensionsVersion);
 
         if (!string.Equals(provider, "None", StringComparison.OrdinalIgnoreCase))
         {

--- a/ServiceScaffolder.cs
+++ b/ServiceScaffolder.cs
@@ -194,7 +194,8 @@ static class ServiceScaffolder
         var classNs = $"{solution}.Infrastructure.Services.HttpRequest";
         WriteHttpRequestClass(infraDir, classNs, cls, iface, ifaceNs);
 
-        InstallPackage(config, "Microsoft.Extensions.Http", "8.0.0");
+        var httpVersion = PackageVersionResolver.ResolveSharedFrameworkPackageVersion(config.TargetFramework);
+        InstallPackage(config, "Microsoft.Extensions.Http", httpVersion);
 
         AddServiceToDi(config, "Infrastructure", iface, ifaceNs, cls, classNs, "AddHttpClient");
         EnsureProgramCalls(config, "Infrastructure");


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the SDK-aligned package version from the chosen target framework
- update solution scaffolding to use the resolved version for EF Core, OpenAPI, and Microsoft.Extensions abstractions to avoid net9 downgrades
- align the HttpRequest service scaffolder with the resolved Microsoft.Extensions.Http package version

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c95c1baec8832cb779301ab802d1d9